### PR TITLE
Fix Trying to access array offset on value of type null

### DIFF
--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -52,7 +52,7 @@ class SequenceFeature extends AbstractFeature
         $values = $insert->getRawState('values');
         $key = array_search($this->primaryKeyField, $columns);
         if ($key !== false) {
-            $this->sequenceValue = $values[$key];
+            $this->sequenceValue = ($values ? $values[$key] : NULL);
             return $insert;
         }
 

--- a/src/TableGateway/Feature/SequenceFeature.php
+++ b/src/TableGateway/Feature/SequenceFeature.php
@@ -52,7 +52,7 @@ class SequenceFeature extends AbstractFeature
         $values = $insert->getRawState('values');
         $key = array_search($this->primaryKeyField, $columns);
         if ($key !== false) {
-            $this->sequenceValue = ($values ? $values[$key] : NULL);
+            $this->sequenceValue = isset($values[$key]) ? $values[$key] : null;
             return $insert;
         }
 


### PR DESCRIPTION
```
There were 2 errors:

1) ZendTest\Db\TableGateway\Feature\SequenceFeatureTest::testPreInsertWillReturnLastInsertValueIfPrimaryKeySetInColumnsData with data set #0 ('PostgreSQL', 'SELECT CURRVAL('table_sequence')')
Trying to access array offset on value of type null

/builddir/build/BUILDROOT/php-zendframework-zend-db-2.11.0-2.fc31.remi.x86_64/usr/share/php/Zend/Db/TableGateway/Feature/SequenceFeature.php:56
/builddir/build/BUILD/zend-db-71626f95f6f9ee326e4be3c34228c1c466300a2c/test/unit/TableGateway/Feature/SequenceFeatureTest.php:158

2) ZendTest\Db\TableGateway\Feature\SequenceFeatureTest::testPreInsertWillReturnLastInsertValueIfPrimaryKeySetInColumnsData with data set #1 ('Oracle', 'SELECT table_sequence.CURRVAL...M dual')
Trying to access array offset on value of type null

/builddir/build/BUILDROOT/php-zendframework-zend-db-2.11.0-2.fc31.remi.x86_64/usr/share/php/Zend/Db/TableGateway/Feature/SequenceFeature.php:56
/builddir/build/BUILD/zend-db-71626f95f6f9ee326e4be3c34228c1c466300a2c/test/unit/TableGateway/Feature/SequenceFeatureTest.php:158

```

Trivial fix which mimics the < 7.4 behavior