### PR TITLE
set return null for HydratingResultSet::current() on no data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- [#39](https://github.com/laminas/laminas-db/pull/39) change `HydratingResultSet::current()` to returns null on no data.
+- [#39](https://github.com/laminas/laminas-db/pull/39) change `HydratingResultSet::current()` to returns `null` on no data (before `false` was returned).
+  **It may be potential BC Break for those who depends on strict type comparision here.**
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#39](https://github.com/laminas/laminas-db/pull/39) change `HydratingResultSet::current()` to returns null on no data.
 
 ### Deprecated
 

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -93,7 +93,7 @@ class HydratingResultSet extends AbstractResultSet
     /**
      * Iterator: get current item
      *
-     * @return object
+     * @return object|null
      */
     public function current()
     {
@@ -103,13 +103,13 @@ class HydratingResultSet extends AbstractResultSet
             return $this->buffer[$this->position];
         }
         $data = $this->dataSource->current();
-        $object = is_array($data) ? $this->hydrator->hydrate($data, clone $this->objectPrototype) : false;
+        $current = is_array($data) ? $this->hydrator->hydrate($data, clone $this->objectPrototype) : null;
 
         if (is_array($this->buffer)) {
-            $this->buffer[$this->position] = $object;
+            $this->buffer[$this->position] = $current;
         }
 
-        return $object;
+        return $current;
     }
 
     /**

--- a/test/unit/ResultSet/HydratingResultSetTest.php
+++ b/test/unit/ResultSet/HydratingResultSetTest.php
@@ -75,7 +75,7 @@ class HydratingResultSetTest extends TestCase
     /**
      * @covers \Laminas\Db\ResultSet\HydratingResultSet::current
      */
-    public function testCurrent()
+    public function testCurrentHasData()
     {
         $hydratingRs = new HydratingResultSet;
         $hydratingRs->initialize([
@@ -83,6 +83,17 @@ class HydratingResultSetTest extends TestCase
         ]);
         $obj = $hydratingRs->current();
         self::assertInstanceOf('ArrayObject', $obj);
+    }
+
+    /**
+     * @covers \Laminas\Db\ResultSet\HydratingResultSet::current
+     */
+    public function testCurrentDoesnotHasData()
+    {
+        $hydratingRs = new HydratingResultSet;
+        $hydratingRs->initialize([]);
+        $result = $hydratingRs->current();
+        self::assertNull($result);
     }
 
     /**


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.
Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

re-create https://github.com/laminas/laminas-db/issues/30 .

- Are you fixing a bug?
   - Detail how the bug is invoked currently.
        call HydratingResultSet::current() on no data in current record.
   - Detail the original, incorrect behavior.
        it returns false.
   - Detail the new, expected behavior.
        it returns null, the "AbstractResultset" and "ResultSet" class returns null on no data, so it returns null for consistency/fix.
    - Base your feature on the master branch, and submit against that branch.
    - Add a regression test that demonstrates the bug, and proves the fix.
    - Add a CHANGELOG.md entry for the fixes

as this is considered a BC break, I target to develop. 
