### PR TITLE
Fix __METHOD__ inside closure (it is '{closure}')

### DIFF
--- a/src/Adapter/Driver/Pgsql/Connection.php
+++ b/src/Adapter/Driver/Pgsql/Connection.php
@@ -124,13 +124,16 @@ class Connection extends AbstractConnection
         $connection = $this->getConnectionString();
         set_error_handler(function ($number, $string) {
             throw new Exception\RuntimeException(
-                __METHOD__ . ': Unable to connect to database',
+                __CLASS__ . '::connect: Unable to connect to database',
                 null,
                 new Exception\ErrorException($string, $number)
             );
         });
-        $this->resource = pg_connect($connection);
-        restore_error_handler();
+        try {
+            $this->resource = pg_connect($connection);
+        } finally {
+            restore_error_handler();
+        }
 
         if ($this->resource === false) {
             throw new Exception\RuntimeException(sprintf(

--- a/test/unit/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/test/unit/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -34,6 +34,27 @@ class ConnectionTest extends TestCase
      *
      * @covers \Laminas\Db\Adapter\Driver\Pgsql\Connection::getResource
      */
+    public function testResourceInvalid()
+    {
+        if (! extension_loaded('pgsql')) {
+            $this->markTestSkipped('pgsql extension not loaded');
+        }
+
+        // invalid port should lead to the custom error handler throwing
+        $conn = new Connection(['socket' => '127.0.0.1', 'port' => 65112]);
+        try {
+            $resource = $conn->getResource();
+            $this->fail('should throw');
+        } catch (AdapterException\RuntimeException $exc) {
+            $this->assertSame('Laminas\Db\Adapter\Driver\Pgsql\Connection::connect: Unable to connect to database', $exc->getMessage());
+        }
+    }
+
+    /**
+     * Test getResource method if it tries to connect to the database.
+     *
+     * @covers \Laminas\Db\Adapter\Driver\Pgsql\Connection::getResource
+     */
     public function testResource()
     {
         if (! extension_loaded('pgsql')) {

--- a/test/unit/Adapter/Driver/Pgsql/ConnectionTest.php
+++ b/test/unit/Adapter/Driver/Pgsql/ConnectionTest.php
@@ -46,7 +46,10 @@ class ConnectionTest extends TestCase
             $resource = $conn->getResource();
             $this->fail('should throw');
         } catch (AdapterException\RuntimeException $exc) {
-            $this->assertSame('Laminas\Db\Adapter\Driver\Pgsql\Connection::connect: Unable to connect to database', $exc->getMessage());
+            $this->assertSame(
+                'Laminas\Db\Adapter\Driver\Pgsql\Connection::connect: Unable to connect to database',
+                $exc->getMessage()
+            );
         }
     }
 


### PR DESCRIPTION
Noticed via static analysis (PhanSuspiciousMagicConstant)


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | ?
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Previously, I think this would emit `{closure}: Unable to connect to database` if the error handler got called.
After this PR, this emits the method name in the error message.