### PR TITLE
Remove impossible check for array === null

### DIFF
--- a/src/Sql/Update.php
+++ b/src/Sql/Update.php
@@ -106,10 +106,6 @@ class Update extends AbstractPreparableSql
      */
     public function set(array $values, $flag = self::VALUES_SET)
     {
-        if ($values === null) {
-            throw new Exception\InvalidArgumentException('set() expects an array of values');
-        }
-
         if ($flag == self::VALUES_SET) {
             $this->set->clear();
         }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This is dead code - The parameter type signature would cause php to throw in the caller if a non-array was passed in.