### PR TITLE
Fixes #47 - Prepared query wrong number of parameter on 2.9.3

### DIFF
--- a/src/Adapter/ParameterContainer.php
+++ b/src/Adapter/ParameterContainer.php
@@ -49,6 +49,11 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
     protected $maxLength = [];
 
     /**
+     * @var array
+     */
+    protected $nameMapping = [];
+
+    /**
      * Constructor
      *
      * @param array $data
@@ -79,7 +84,15 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      */
     public function offsetGet($name)
     {
-        return (isset($this->data[$name])) ? $this->data[$name] : null;
+        if (isset($this->data[$name])) {
+            return $this->data[$name];
+        }
+
+        if (isset($this->nameMapping[$name])) {
+            return $this->data[$this->nameMapping[$name]];
+        }
+
+        return null;
     }
 
     /**
@@ -160,6 +173,20 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
     public function setFromArray(array $data)
     {
         foreach ($data as $n => $v) {
+            if (is_string($n)) {
+                if (! isset($this->nameMapping[$n])) {
+                    foreach ($this->data as $nm => $vm) {
+                        if (ltrim(':', $vm) == ltrim(':', $n)) {
+                            $this->nameMapping[$n] = $nm;
+                            break;
+                        }
+                    }
+                }
+                if (! isset($this->nameMapping[$n])) {
+                    $this->nameMapping[$n] = $n;
+                }
+                $n = $this->nameMapping[$n];
+            }
             $this->offsetSet($n, $v);
         }
         return $this;

--- a/src/Adapter/ParameterContainer.php
+++ b/src/Adapter/ParameterContainer.php
@@ -176,7 +176,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
             if (is_string($n)) {
                 if (! isset($this->nameMapping[$n])) {
                     foreach ($this->data as $nm => $vm) {
-                        if (ltrim(':', $vm) == ltrim(':', $n)) {
+                        if (ltrim($vm, ':') == ltrim($n, ':')) {
                             $this->nameMapping[$n] = $nm;
                             break;
                         }

--- a/src/Adapter/ParameterContainer.php
+++ b/src/Adapter/ParameterContainer.php
@@ -88,7 +88,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
             return $this->data[$name];
         }
 
-        if (isset($this->nameMapping[$name])) {
+        if (isset($this->nameMapping[$name]) && isset($this->data[$this->nameMapping[$name]])) {
             return $this->data[$this->nameMapping[$name]];
         }
 

--- a/src/Adapter/ParameterContainer.php
+++ b/src/Adapter/ParameterContainer.php
@@ -88,8 +88,8 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
             return $this->data[$name];
         }
 
-        if (isset($this->nameMapping[$name]) && isset($this->data[$this->nameMapping[$name]])) {
-            return $this->data[$this->nameMapping[$name]];
+        if (isset($this->nameMapping[ltrim($name, ':')]) && isset($this->data[$this->nameMapping[ltrim($name, ':')]])) {
+            return $this->data[$this->nameMapping[ltrim($name, ':')]];
         }
 
         return null;
@@ -127,7 +127,15 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
             }
         } elseif (is_string($name)) {
             // is a string:
+            if (isset($this->nameMapping[ltrim($name, ':')])) {
+                //we have a mapping, get real name from it
+                $name = $this->nameMapping[ltrim($name, ':')];
+            }
             $position = array_key_exists($name, $this->data);
+            if (strpos($value, ':') === 0) { //FIXME: any data begining with a ":" will be considered a parameter
+                //We have named parameter, handle name mapping (container creation)
+                $this->nameMapping[ltrim($value, ':')] = $name;
+            }
         } elseif ($name === null) {
             $name = (string) count($this->data);
         } else {
@@ -173,20 +181,6 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
     public function setFromArray(array $data)
     {
         foreach ($data as $n => $v) {
-            if (is_string($n)) {
-                if (! isset($this->nameMapping[$n])) {
-                    foreach ($this->data as $nm => $vm) {
-                        if (ltrim($vm, ':') == ltrim($n, ':')) {
-                            $this->nameMapping[$n] = $nm;
-                            break;
-                        }
-                    }
-                }
-                if (! isset($this->nameMapping[$n])) {
-                    $this->nameMapping[$n] = $n;
-                }
-                $n = $this->nameMapping[$n];
-            }
             $this->offsetSet($n, $v);
         }
         return $this;

--- a/test/integration/Adapter/Driver/Pdo/Mysql/QueryTest.php
+++ b/test/integration/Adapter/Driver/Pdo/Mysql/QueryTest.php
@@ -66,4 +66,40 @@ class QueryTest extends TestCase
     {
         $result = $this->adapter->query('SET @@session.time_zone = :tz$', [':tz$' => 'SYSTEM']);
     }
+
+    /**
+     * @see https://github.com/laminas/laminas-db/issues/47
+     */
+    public function testNamedParameters()
+    {
+        $sql = new \Laminas\Db\Sql\Sql($this->adapter);
+
+        $insert = $sql->update('test');
+        $insert->set([
+            'name'  => ':name',
+            'value' => ':value'
+        ])->where(['id' => ':id']);
+        $stmt = $sql->prepareStatementForSqlObject($insert);
+
+        //positional parameters
+        $stmt->execute([
+            1,
+            'foo',
+            'bar'
+        ]);
+
+        //"mapped" named parameters
+        $stmt->execute([
+            'c_0'    => 1,
+            'c_1'    => 'foo',
+            'where1' => 'bar'
+        ]);
+
+        //real named parameters
+        $stmt->execute([
+            'id'    => 1,
+            'name'  => 'foo',
+            'value' => 'bar'
+        ]);
+    }
 }

--- a/test/unit/Adapter/ParameterContainerTest.php
+++ b/test/unit/Adapter/ParameterContainerTest.php
@@ -131,9 +131,6 @@ class ParameterContainerTest extends TestCase
         $this->parameterContainer->setFromArray([':myparam' => 'baz']);
         self::assertEquals('baz', $this->parameterContainer['c_0']);
         self::assertEquals('baz', $this->parameterContainer[':myparam']);
-        $this->parameterContainer->setFromArray([':myparam' => 'baz2']);
-        self::assertEquals('baz2', $this->parameterContainer[':myparam']);
-        self::assertEquals('baz2', $this->parameterContainer['c_0']);
     }
 
     /**

--- a/test/unit/Adapter/ParameterContainerTest.php
+++ b/test/unit/Adapter/ParameterContainerTest.php
@@ -125,8 +125,17 @@ class ParameterContainerTest extends TestCase
     {
         $this->parameterContainer->setFromArray(['bar' => 'baz']);
         self::assertEquals('baz', $this->parameterContainer['bar']);
-        //Handle statement parameters - https://github.com/laminas/laminas-db/issues/47
-        //@see Insert::procesInsert as example
+    }
+
+    /**
+     *
+     * Handle statement parameters - https://github.com/laminas/laminas-db/issues/47
+     * @see Insert::procesInsert as example
+     *
+     * @covers \Laminas\Db\Adapter\ParameterContainer::setFromArray
+     */
+    public function testSetFromArrayNamed()
+    {
         $this->parameterContainer->offsetSet('c_0', ':myparam');
         $this->parameterContainer->setFromArray([':myparam' => 'baz']);
         self::assertEquals('baz', $this->parameterContainer['c_0']);

--- a/test/unit/Adapter/ParameterContainerTest.php
+++ b/test/unit/Adapter/ParameterContainerTest.php
@@ -125,6 +125,15 @@ class ParameterContainerTest extends TestCase
     {
         $this->parameterContainer->setFromArray(['bar' => 'baz']);
         self::assertEquals('baz', $this->parameterContainer['bar']);
+        //Handle statement parameters - https://github.com/laminas/laminas-db/issues/47
+        //@see Insert::procesInsert as example
+        $this->parameterContainer->offsetSet('c_0', ':myparam');
+        $this->parameterContainer->setFromArray([':myparam' => 'baz']);
+        self::assertEquals('baz', $this->parameterContainer['c_0']);
+        self::assertEquals('baz', $this->parameterContainer[':myparam']);
+        $this->parameterContainer->setFromArray([':myparam' => 'baz2']);
+        self::assertEquals('baz2', $this->parameterContainer[':myparam']);
+        self::assertEquals('baz2', $this->parameterContainer['c_0']);
     }
 
     /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Juste to reproduce #47 as asked.