### PR TITLE
remove wrong driver/platform-name combination from oracle-platform

### DIFF
--- a/src/Adapter/Platform/Oracle.php
+++ b/src/Adapter/Platform/Oracle.php
@@ -47,7 +47,6 @@ class Oracle extends AbstractPlatform
     {
         if ($driver instanceof Oci8
             || ($driver instanceof Pdo && $driver->getDatabasePlatformName() == 'Oracle')
-            || ($driver instanceof Pdo && $driver->getDatabasePlatformName() == 'Sqlite')
             || ($driver instanceof \oci8)
             || ($driver instanceof \PDO && $driver->getAttribute(\PDO::ATTR_DRIVER_NAME) == 'oci')
         ) {

--- a/test/unit/Adapter/AdapterTest.php
+++ b/test/unit/Adapter/AdapterTest.php
@@ -159,7 +159,7 @@ class AdapterTest extends TestCase
 
         // ensure platform can created via string, and also that it passed in options to platform object
         $driver = [
-            'driver' => 'pdo_sqlite',
+            'driver' => 'pdo_oci',
             'platform' => 'Oracle',
             'platform_options' => ['quote_identifiers' => false],
         ];


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
The Oracle platform should not allow a PDO-based driver built from 'pdo_sqlite' driver-name config.
Not sure why the adapter test allowed it as well, but the exception message makes it clear it should not.