### PR TITLE
add resultPrototype getter for inspection

### DIFF
--- a/src/Adapter/Driver/IbmDb2/IbmDb2.php
+++ b/src/Adapter/Driver/IbmDb2/IbmDb2.php
@@ -180,6 +180,14 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
+     * @return Result
+     */
+    public function getResultPrototype()
+    {
+        return $this->resultPrototype;
+    }
+
+    /**
      * Get prepare type
      *
      * @return string

--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -288,6 +288,14 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     }
 
     /**
+     * @return Result
+     */
+    public function getResultPrototype()
+    {
+        return $this->resultPrototype;
+    }
+
+    /**
      * @return string
      */
     public function getPrepareType()

--- a/src/Adapter/Driver/Pgsql/Pgsql.php
+++ b/src/Adapter/Driver/Pgsql/Pgsql.php
@@ -202,6 +202,14 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
+     * @return Result
+     */
+    public function getResultPrototype()
+    {
+        return $this->resultPrototype;
+    }
+
+    /**
      * Get prepare Type
      *
      * @return string

--- a/src/Adapter/Driver/Sqlsrv/Sqlsrv.php
+++ b/src/Adapter/Driver/Sqlsrv/Sqlsrv.php
@@ -187,6 +187,14 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
+     * @return Result
+     */
+    public function getResultPrototype()
+    {
+        return $this->resultPrototype;
+    }
+
+    /**
      * @return string
      */
     public function getPrepareType()

--- a/test/unit/Adapter/Driver/IbmDb2/IbmDb2Test.php
+++ b/test/unit/Adapter/Driver/IbmDb2/IbmDb2Test.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Db\Adapter\Driver\IbmDb2;
 
 use Laminas\Db\Adapter\Driver\IbmDb2\IbmDb2;
+use Laminas\Db\Adapter\Driver\IbmDb2\Result;
 use PHPUnit\Framework\TestCase;
 
 class IbmDb2Test extends TestCase
@@ -161,5 +162,15 @@ class IbmDb2Test extends TestCase
         $this->markTestIncomplete(
             'This test has not been implemented yet.'
         );
+    }
+
+    /**
+     * @covers \Laminas\Db\Adapter\Driver\IbmDb2\IbmDb2::getResultPrototype
+     */
+    public function testGetResultPrototype()
+    {
+        $resultPrototype = $this->ibmdb2->getResultPrototype();
+
+        self::assertInstanceOf(Result::class, $resultPrototype);
     }
 }

--- a/test/unit/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/unit/Adapter/Driver/Pdo/PdoTest.php
@@ -93,6 +93,6 @@ class PdoTest extends TestCase
     {
         $resultPrototype = $this->pdo->getResultPrototype();
         
-        self::assert($resultPrototype instanceof Result);
+        self::assertInstanceOf(Result, $resultPrototype);
     }
 }

--- a/test/unit/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/unit/Adapter/Driver/Pdo/PdoTest.php
@@ -90,7 +90,7 @@ class PdoTest extends TestCase
      */
     public function testGetResultPrototype()
     {
-        $resultPrototype = $this->getResultPrototype();
+        $resultPrototype = $this->pdo->getResultPrototype();
         
         self::assert($resultPrototype instanceof \Laminas\Db\Adapter\Driver\Pdo\Result);
     }

--- a/test/unit/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/unit/Adapter/Driver/Pdo/PdoTest.php
@@ -84,4 +84,14 @@ class PdoTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->pdo->formatParameterName($name);
     }
+    
+    /**
+     * @covers \Laminas\Db\Adapter\Driver\Pdo\Pdo::getResultPrototype
+     */
+    public function testGetResultPrototype()
+    {
+        $resultPrototype = $this->getResultPrototype();
+        
+        self::assert($resultPrototype instanceof \Laminas\Db\Adapter\Driver\Pdo\Result);
+    }
 }

--- a/test/unit/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/unit/Adapter/Driver/Pdo/PdoTest.php
@@ -85,14 +85,14 @@ class PdoTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->pdo->formatParameterName($name);
     }
-    
+
     /**
      * @covers \Laminas\Db\Adapter\Driver\Pdo\Pdo::getResultPrototype
      */
     public function testGetResultPrototype()
     {
         $resultPrototype = $this->pdo->getResultPrototype();
-        
+
         self::assertInstanceOf(Result::class, $resultPrototype);
     }
 }

--- a/test/unit/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/unit/Adapter/Driver/Pdo/PdoTest.php
@@ -10,6 +10,7 @@ namespace LaminasTest\Db\Adapter\Driver\Pdo;
 
 use Laminas\Db\Adapter\Driver\DriverInterface;
 use Laminas\Db\Adapter\Driver\Pdo\Pdo;
+use Laminas\Db\Adapter\Driver\Pdo\Result;
 use Laminas\Db\Exception\RuntimeException;
 use PHPUnit\Framework\TestCase;
 
@@ -92,6 +93,6 @@ class PdoTest extends TestCase
     {
         $resultPrototype = $this->pdo->getResultPrototype();
         
-        self::assert($resultPrototype instanceof \Laminas\Db\Adapter\Driver\Pdo\Result);
+        self::assert($resultPrototype instanceof Result);
     }
 }

--- a/test/unit/Adapter/Driver/Pdo/PdoTest.php
+++ b/test/unit/Adapter/Driver/Pdo/PdoTest.php
@@ -93,6 +93,6 @@ class PdoTest extends TestCase
     {
         $resultPrototype = $this->pdo->getResultPrototype();
         
-        self::assertInstanceOf(Result, $resultPrototype);
+        self::assertInstanceOf(Result::class, $resultPrototype);
     }
 }

--- a/test/unit/Adapter/Driver/Pgsql/PgsqlTest.php
+++ b/test/unit/Adapter/Driver/Pgsql/PgsqlTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Db\Adapter\Driver\Pgsql;
 
 use Laminas\Db\Adapter\Driver\Pgsql\Pgsql;
+use Laminas\Db\Adapter\Driver\Pgsql\Result;
 use PHPUnit\Framework\TestCase;
 
 class PgsqlTest extends TestCase
@@ -173,5 +174,15 @@ class PgsqlTest extends TestCase
         $this->markTestIncomplete(
             'This test has not been implemented yet.'
         );
+    }
+
+    /**
+     * @covers \Laminas\Db\Adapter\Driver\Pgsql\Pgsql::getResultPrototype
+     */
+    public function testGetResultPrototype()
+    {
+        $resultPrototype = $this->pgsql->getResultPrototype();
+
+        self::assertInstanceOf(Result::class, $resultPrototype);
     }
 }

--- a/test/unit/Adapter/Driver/Sqlsrv/SqlsrvTest.php
+++ b/test/unit/Adapter/Driver/Sqlsrv/SqlsrvTest.php
@@ -8,6 +8,7 @@
 
 namespace LaminasTest\Db\Adapter\Driver\Sqlsrv;
 
+use Laminas\Db\Adapter\Driver\Sqlsrv\Result;
 use Laminas\Db\Adapter\Driver\Sqlsrv\Sqlsrv;
 use PHPUnit\Framework\TestCase;
 
@@ -161,5 +162,15 @@ class SqlsrvTest extends TestCase
         $this->markTestIncomplete(
             'This test has not been implemented yet.'
         );
+    }
+
+    /**
+     * @covers \Laminas\Db\Adapter\Driver\Sqlsrv\Sqlsrv::getResultPrototype
+     */
+    public function testGetResultPrototype()
+    {
+        $resultPrototype = $this->sqlsrv->getResultPrototype();
+
+        self::assertInstanceOf(Result::class, $resultPrototype);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no?
| New Feature   | yes?
| RFC           | no
| QA            | no

### Description
I would like to have access to the prototype so that I can set the fetch mode to be able to change the prototype's fetchmode based on what type of sql I execute

### Note
I had to clone the original since the branch got lost
