### PR TITLE
Adds delegator for AdapterAwareInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-eventmanager": "^3.3",
         "laminas/laminas-hydrator": "^3.2 || ^4.0",
-        "laminas/laminas-servicemanager": "^3.0.3",
+        "laminas/laminas-servicemanager": "^3.3",
         "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "919a0a182fb526074cfc24bc12dbacd3",
+    "content-hash": "e23ea3bb7a9e04cec07745d09eb7c135",
     "packages": [
         {
             "name": "laminas/laminas-stdlib",
@@ -347,16 +347,16 @@
         },
         {
             "name": "laminas/laminas-hydrator",
-            "version": "3.2.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-hydrator.git",
-                "reference": "f0336699910478cc45c7e34ca0fc83bf118e48bc"
+                "reference": "fc201f29280a8308579e7fb4c1fbc2fb3dfdbd8f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-hydrator/zipball/f0336699910478cc45c7e34ca0fc83bf118e48bc",
-                "reference": "f0336699910478cc45c7e34ca0fc83bf118e48bc",
+                "url": "https://api.github.com/repos/laminas/laminas-hydrator/zipball/fc201f29280a8308579e7fb4c1fbc2fb3dfdbd8f",
+                "reference": "fc201f29280a8308579e7fb4c1fbc2fb3dfdbd8f",
                 "shasum": ""
             },
             "require": {
@@ -374,7 +374,8 @@
                 "laminas/laminas-serializer": "^2.9",
                 "laminas/laminas-servicemanager": "^3.3.2",
                 "phpunit/phpunit": "~9.3.0",
-                "vimeo/psalm": "^3.16"
+                "psalm/plugin-phpunit": "^0.15.0",
+                "vimeo/psalm": "^4.2"
             },
             "suggest": {
                 "laminas/laminas-eventmanager": "^3.2, to support aggregate hydrator usage",
@@ -417,7 +418,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-06T19:45:29+00:00"
+            "time": "2020-12-16T21:35:39+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",

--- a/docs/book/adapters/adapter-aware-trait.md
+++ b/docs/book/adapters/adapter-aware-trait.md
@@ -10,7 +10,7 @@ instance of `Laminas\Db\Adapter\Adapter`:
 
 ```php
 public function setDbAdapter(\Laminas\Db\Adapter\Adapter $adapter) : self;
-``` 
+```
 
 ## Basic Usage
 

--- a/docs/book/adapters/adapter-aware-trait.md
+++ b/docs/book/adapters/adapter-aware-trait.md
@@ -1,0 +1,124 @@
+# AdapterAwareTrait
+
+The trait `Laminas\Db\Adapter\AdapterAwareTrait`, which provides implementation
+for `Laminas\Db\Adapter\AdapterAwareInterface`, and allowed removal of
+duplicated implementations in several components of Laminas or in custom
+applications.
+
+The interface defines only the method `setDbAdapter()` with one parameter for an
+instance of `Laminas\Db\Adapter\Adapter`:
+
+```php
+public function setDbAdapter(\Laminas\Db\Adapter\Adapter $adapter) : self;
+``` 
+
+## Basic Usage
+
+### Create Class and Add Trait
+
+```php
+use Laminas\Db\Adapter\AdapterAwareTrait;
+use Laminas\Db\Adapter\AdapterAwareInterface;
+
+class Example implements AdapterAwareInterface
+{
+    use AdapterAwareTrait;
+}
+```
+
+### Create and Set Adapter
+
+[Create a database adapter](../adapter.md#creating-an-adapter-using-configuration) and set the adapter to the instance of the `Example`
+class:
+
+```php
+$adapter = new Laminas\Db\Adapter\Adapter([
+    'driver'   => 'Pdo_Sqlite',
+    'database' => 'path/to/sqlite.db',
+]);
+
+$example = new Example();
+$example->setAdapter($adapter);
+```
+
+## AdapterServiceDelegator
+
+The [delegator](https://docs.laminas.dev/laminas-servicemanager/delegators/)
+`Laminas\Db\Adapter\AdapterServiceDelegator` can be used to set a database
+adapter via the [service manager of laminas-servicemanager](https://docs.laminas.dev/laminas-servicemanager/quick-start/).
+
+The delegator tries to fetch a database adapter from the service container and
+sets the adapter to the requested service.
+
+### Create Class and Use Trait
+
+Create a class and add the trait `AdapterAwareTrait`.
+
+```php
+use Laminas\Db\Adapter\Adapter;
+use Laminas\Db\Adapter\AdapterInterface;
+
+class Example implements AdapterAwareInterface
+{
+    use AdapterAwareTrait;
+
+    public function getAdapter() : Adapter
+    {
+        return $this->adapter;
+    }
+}
+```
+
+(A getter method is also added for demonstration.)
+
+### Create and Configure Service Manager
+
+Create and [configured the service manager](https://docs.laminas.dev/laminas-servicemanager/configuring-the-service-manager/):
+
+```php
+use Interop\Container\ContainerInterface;
+use Laminas\Db\Adapter\AdapterInterface;
+use Laminas\Db\Adapter\AdapterServiceDelegator;
+use Laminas\Db\Adapter\AdapterAwareTrait;
+use Laminas\Db\Adapter\AdapterAwareInterface;
+
+$serviceManager = new Laminas\ServiceManager\ServiceManager([
+    'factories' => [
+        // Database adapter
+        AdapterInterface::class => static function(ContainerInterface $container) {
+            return new Laminas\Db\Adapter\Adapter([
+                'driver'   => 'Pdo_Sqlite',
+                'database' => 'path/to/sqlite.db',
+            ]);
+        }
+    ],
+    'invokables' => [
+        // Example class
+        Example::class => Example::class,
+    ],
+    'delegators' => [
+        // Delegator for Example class to set the adapter
+        Example::class => [
+            AdapterServiceDelegator::class,
+        ],
+    ],
+]);
+```
+
+### Get Instance of Class
+
+[Retrieving an instance](https://docs.laminas.dev/laminas-servicemanager/quick-start/#3-retrieving-objects)
+of the `Example` with a database adapter:
+
+```php
+/** @var Example $example */
+$example = $serviceManager->get(Example::class);
+
+var_dump($example->getAdapter() instanceof Laminas\Db\Adapter\Adapter); // true
+```
+
+## Concrete Implementations
+
+The validators [`Db\RecordExists` and `Db\NoRecordExists`](https://docs.laminas.dev/laminas-validator/validators/db/)
+implements the trait and the plugin manager of [laminas-validator](https://docs.laminas.dev/laminas-validator/)
+includes the delegator to set the database adapter for both validators.

--- a/docs/book/adapters/adapter-aware-trait.md
+++ b/docs/book/adapters/adapter-aware-trait.md
@@ -47,8 +47,15 @@ The [delegator](https://docs.laminas.dev/laminas-servicemanager/delegators/)
 `Laminas\Db\Adapter\AdapterServiceDelegator` can be used to set a database
 adapter via the [service manager of laminas-servicemanager](https://docs.laminas.dev/laminas-servicemanager/quick-start/).
 
-The delegator tries to fetch a database adapter from the service container and
-sets the adapter to the requested service.
+The delegator tries to fetch a database adapter via the name
+`Laminas\Db\Adapter\AdapterInterface` from the service container and sets the
+adapter to the requested service. The adapter itself must be an instance of
+`Laminas\Db\Adapter\Adapter`.
+
+> ### Integration for Mezzio and laminas-mvc based Applications
+>
+> In a Mezzio or laminas-mvc based application the database adapter is already
+> registered during the installation with the laminas-component-installer.
 
 ### Create Class and Use Trait
 
@@ -108,7 +115,7 @@ $serviceManager = new Laminas\ServiceManager\ServiceManager([
 ### Get Instance of Class
 
 [Retrieving an instance](https://docs.laminas.dev/laminas-servicemanager/quick-start/#3-retrieving-objects)
-of the `Example` with a database adapter:
+of the `Example` class with a database adapter:
 
 ```php
 /** @var Example $example */

--- a/docs/book/adapters/adapter-aware-trait.md
+++ b/docs/book/adapters/adapter-aware-trait.md
@@ -69,7 +69,7 @@ class Example implements AdapterAwareInterface
 {
     use AdapterAwareTrait;
 
-    public function getAdapter() : Adapter
+    public function getAdapter() : ?Adapter
     {
         return $this->adapter;
     }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,16 +2,17 @@ docs_dir: docs/book
 site_dir: docs/html
 nav:
     - Home: index.md
-    - Reference:
-        - Adapters: adapter.md
-        - "Result Sets": result-set.md
-        - "SQL Abstraction": sql.md
-        - "DDL Abstraction": sql-ddl.md
-        - "Table Gateways": table-gateway.md
-        - "Row Gateways": row-gateway.md
-        - "RDBMS Metadata": metadata.md
-        - "Application Integration":
-          - "Integrating in a Laminas MVC application": application-integration/usage-in-a-laminas-mvc-application.md
+    - Adapters:
+        - Introduction: adapter.md
+        - AdapterAwareTrait: adapters/adapter-aware-trait.md
+    - "Result Sets": result-set.md
+    - "SQL Abstraction": sql.md
+    - "DDL Abstraction": sql-ddl.md
+    - "Table Gateways": table-gateway.md
+    - "Row Gateways": row-gateway.md
+    - "RDBMS Metadata": metadata.md
+    - "Application Integration":
+        - "Integrating in a Laminas MVC application": application-integration/usage-in-a-laminas-mvc-application.md
 site_name: laminas-db
 site_description: "Database abstraction layer, SQL abstraction, result set abstraction, and RowDataGateway and TableDataGateway implementations"
 repo_url: 'https://github.com/laminas/laminas-db'

--- a/src/Adapter/AdapterServiceDelegator.php
+++ b/src/Adapter/AdapterServiceDelegator.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-db for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-db/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-db/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Db\Adapter;
+
+use Psr\Container\ContainerInterface;
+
+class AdapterServiceDelegator
+{
+    /** @var string */
+    private $adapterName;
+
+    public function __construct(string $adapterName = AdapterInterface::class)
+    {
+        $this->adapterName = $adapterName;
+    }
+
+    public static function __set_state(array $state) : self
+    {
+        return new self($state['adapterName'] ?? AdapterInterface::class);
+    }
+
+    public function __invoke(
+        ContainerInterface $container,
+        string $name,
+        callable $callback,
+        array $options = null
+    ) {
+        $instance = $callback();
+
+        if (! $instance instanceof AdapterAwareInterface) {
+            return $instance;
+        }
+
+        if (! $container->has($this->adapterName)) {
+            return $instance;
+        }
+
+        $databaseAdapter = $container->get($this->adapterName);
+
+        if (! $databaseAdapter instanceof Adapter) {
+            return $instance;
+        }
+
+        $instance->setDbAdapter($databaseAdapter);
+
+        return $instance;
+    }
+}

--- a/test/unit/Adapter/AdapterServiceDelegatorTest.php
+++ b/test/unit/Adapter/AdapterServiceDelegatorTest.php
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-db for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-db/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-db/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Db\Adapter;
+
+use Laminas\Db\Adapter\Adapter;
+use Laminas\Db\Adapter\AdapterAwareInterface;
+use Laminas\Db\Adapter\AdapterInterface;
+use Laminas\Db\Adapter\AdapterServiceDelegator;
+use Laminas\Db\Adapter\Driver\DriverInterface;
+use Laminas\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\ServiceManager;
+use LaminasTest\Db\Adapter\TestAsset\ConcreteAdapterAwareObject;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Container\ContainerInterface;
+use stdClass;
+
+class AdapterServiceDelegatorTest extends TestCase
+{
+    public function testSetAdapterShouldBeCalledForExistingAdapter() : void
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(AdapterInterface::class)
+            ->shouldBeCalledOnce()
+            ->willReturn(true);
+        $container->get(AdapterInterface::class)
+            ->shouldBeCalledOnce()
+            ->willReturn(
+                $this->prophesize(Adapter::class)->reveal()
+            );
+
+        $callback = static function () {
+            return new ConcreteAdapterAwareObject();
+        };
+
+        /** @var ConcreteAdapterAwareObject $result */
+        $result = (new AdapterServiceDelegator())(
+            $container->reveal(),
+            'name',
+            $callback
+        );
+
+        $this->assertInstanceOf(
+            AdapterInterface::class,
+            $result->getAdapter()
+        );
+    }
+
+    public function testSetAdapterShouldBeCalledForOnlyConcreteAdapter() : void
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(AdapterInterface::class)
+            ->shouldBeCalledOnce()
+            ->willReturn(true);
+        $container->get(AdapterInterface::class)
+            ->shouldBeCalledOnce()
+            ->willReturn(
+                $this->prophesize(AdapterInterface::class)->reveal()
+            );
+
+        $callback = static function () {
+            return new ConcreteAdapterAwareObject();
+        };
+
+        /** @var ConcreteAdapterAwareObject $result */
+        $result = (new AdapterServiceDelegator())(
+            $container->reveal(),
+            'name',
+            $callback
+        );
+
+        $this->assertNull($result->getAdapter());
+    }
+
+    public function testSetAdapterShouldNotBeCalledForMissingAdapter() : void
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(AdapterInterface::class)
+            ->shouldBeCalledOnce()
+            ->willReturn(false);
+        $container->get(Argument::any())->shouldNotBeCalled();
+
+        $callback = static function () {
+            return new ConcreteAdapterAwareObject();
+        };
+
+        /** @var ConcreteAdapterAwareObject $result */
+        $result = (new AdapterServiceDelegator())(
+            $container->reveal(),
+            'name',
+            $callback
+        );
+
+        $this->assertNull($result->getAdapter());
+    }
+
+    public function testSetAdapterShouldNotBeCalledForWrongClassInstance(
+    ) : void
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has(Argument::any())->shouldNotBeCalled();
+
+        $callback = static function () {
+            return new stdClass();
+        };
+
+        $result = (new AdapterServiceDelegator())(
+            $container->reveal(),
+            'name',
+            $callback
+        );
+
+        $this->assertNotInstanceOf(AdapterAwareInterface::class, $result);
+    }
+
+    public function testDelegatorWithServiceManager()
+    {
+        $databaseAdapter = new Adapter(
+            $this->prophesize(DriverInterface::class)->reveal()
+        );
+
+        $container = new ServiceManager([
+            'invokables' => [
+                ConcreteAdapterAwareObject::class => ConcreteAdapterAwareObject::class,
+            ],
+            'factories'  => [
+                AdapterInterface::class => static function () use (
+                    $databaseAdapter
+                ) {
+                    return $databaseAdapter;
+                },
+            ],
+            'delegators' => [
+                ConcreteAdapterAwareObject::class => [
+                    AdapterServiceDelegator::class,
+                ],
+            ],
+        ]);
+
+        /** @var ConcreteAdapterAwareObject $result */
+        $result = $container->get(ConcreteAdapterAwareObject::class);
+
+        $this->assertInstanceOf(
+            AdapterInterface::class,
+            $result->getAdapter()
+        );
+    }
+
+    public function testDelegatorWithServiceManagerAndCustomAdapterName()
+    {
+        $databaseAdapter = new Adapter(
+            $this->prophesize(DriverInterface::class)->reveal()
+        );
+
+        $container = new ServiceManager([
+            'invokables' => [
+                ConcreteAdapterAwareObject::class => ConcreteAdapterAwareObject::class,
+            ],
+            'factories'  => [
+                'alternate-database-adapter' => static function () use (
+                    $databaseAdapter
+                ) {
+                    return $databaseAdapter;
+                },
+            ],
+            'delegators' => [
+                ConcreteAdapterAwareObject::class => [
+                    new AdapterServiceDelegator('alternate-database-adapter'),
+                ],
+            ],
+        ]);
+
+        /** @var ConcreteAdapterAwareObject $result */
+        $result = $container->get(ConcreteAdapterAwareObject::class);
+
+        $this->assertInstanceOf(
+            AdapterInterface::class,
+            $result->getAdapter()
+        );
+    }
+
+    public function testDelegatorWithPluginManager()
+    {
+        $databaseAdapter = new Adapter(
+            $this->prophesize(DriverInterface::class)->reveal()
+        );
+
+        $container           = new ServiceManager([
+            'factories' => [
+                AdapterInterface::class => static function () use (
+                    $databaseAdapter
+                ) {
+                    return $databaseAdapter;
+                },
+            ],
+        ]);
+        $pluginManagerConfig = [
+            'invokables' => [
+                ConcreteAdapterAwareObject::class => ConcreteAdapterAwareObject::class,
+            ],
+            'delegators' => [
+                ConcreteAdapterAwareObject::class => [
+                    AdapterServiceDelegator::class,
+                ],
+            ],
+        ];
+
+        /** @var AbstractPluginManager $pluginManager */
+        $pluginManager = new class($container, $pluginManagerConfig)
+            extends AbstractPluginManager {
+        };
+
+        $options = [
+            'table' => 'foo',
+            'field' => 'bar',
+        ];
+
+        /** @var ConcreteAdapterAwareObject $result */
+        $result = $pluginManager->get(
+            ConcreteAdapterAwareObject::class,
+            $options
+        );
+
+        $this->assertInstanceOf(
+            AdapterInterface::class,
+            $result->getAdapter()
+        );
+        $this->assertSame($options, $result->getOptions());
+    }
+}

--- a/test/unit/Adapter/AdapterServiceDelegatorTest.php
+++ b/test/unit/Adapter/AdapterServiceDelegatorTest.php
@@ -18,11 +18,14 @@ use Laminas\ServiceManager\ServiceManager;
 use LaminasTest\Db\Adapter\TestAsset\ConcreteAdapterAwareObject;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Container\ContainerInterface;
 use stdClass;
 
 class AdapterServiceDelegatorTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testSetAdapterShouldBeCalledForExistingAdapter() : void
     {
         $container = $this->prophesize(ContainerInterface::class);

--- a/test/unit/Adapter/AdapterServiceDelegatorTest.php
+++ b/test/unit/Adapter/AdapterServiceDelegatorTest.php
@@ -100,8 +100,7 @@ class AdapterServiceDelegatorTest extends TestCase
         $this->assertNull($result->getAdapter());
     }
 
-    public function testSetAdapterShouldNotBeCalledForWrongClassInstance(
-    ) : void
+    public function testSetAdapterShouldNotBeCalledForWrongClassInstance() : void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has(Argument::any())->shouldNotBeCalled();

--- a/test/unit/Adapter/TestAsset/ConcreteAdapterAwareObject.php
+++ b/test/unit/Adapter/TestAsset/ConcreteAdapterAwareObject.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-db for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-db/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-db/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Db\Adapter\TestAsset;
+
+use Laminas\Db\Adapter\AdapterAwareInterface;
+use Laminas\Db\Adapter\AdapterAwareTrait;
+use Laminas\Db\Adapter\AdapterInterface;
+
+class ConcreteAdapterAwareObject implements AdapterAwareInterface
+{
+    use AdapterAwareTrait;
+
+    /** @var array */
+    private $options;
+
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
+    public function getAdapter() : ?AdapterInterface
+    {
+        return $this->adapter;
+    }
+
+    public function getOptions() : array
+    {
+        return $this->options;
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

## Description

The delegator allows the setting of an adapter for a class which implements the `Laminas\Db\Adapter\AdapterAwareInterface`.

## Example

A concrete example are the database validators [`RecordExists` and `NoRecordExists`](https://docs.laminas.dev/laminas-validator/validators/db/). Is a database adapter registered and the delegator is present in the validator plugin manager then following configuration can be used in a form:

```php
public function getInputFilterSpecification() : array
{
    return [
        [
            'name'       => 'form-element',
            'validators' => [
                [
                    'name'    => RecordExists::class,
                    'options' => [
                        'table' => 'foo',
                        'field' => 'bar',
                    ],
                ],
            ],
        ],
    ];
}
```
It is not necessary to create a factory or set the database adapter to form or validator manually.

(The next step is to extend the validator plugin manager.)

---

_The increase of the PHP version is needed._