### PR TITLE
Fix MySQLi SSL flags handling to explicitly set MYSQLI_CLIENT_SSL if …

### DIFF
--- a/test/unit/Adapter/Driver/Mysqli/ConnectionTest.php
+++ b/test/unit/Adapter/Driver/Mysqli/ConnectionTest.php
@@ -64,6 +64,62 @@ class ConnectionTest extends TestCase
         self::assertEquals(['foo' => 'bar'], $this->connection->getConnectionParameters());
     }
 
+    public function testNonSecureConnection()
+    {
+        $mysqli = $this->createMockMysqli(0);
+        $connection = $this->createMockConnection(
+            $mysqli,
+            [
+                'hostname' => 'localhost',
+                'username' => 'superuser',
+                'password' => '1234',
+                'database' => 'main',
+                'port' => 123,
+            ]
+        );
+
+        $connection->connect();
+    }
+
+    public function testSslConnection()
+    {
+        $mysqli = $this->createMockMysqli(MYSQLI_CLIENT_SSL);
+        $connection = $this->createMockConnection(
+            $mysqli,
+            [
+                'hostname' => 'localhost',
+                'username' => 'superuser',
+                'password' => '1234',
+                'database' => 'main',
+                'port' => 123,
+                'use_ssl' => true,
+            ]
+        );
+
+        $connection->connect();
+    }
+
+    public function testSslConnectionNoVerify()
+    {
+        $mysqli = $this->createMockMysqli(MYSQLI_CLIENT_SSL | MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT);
+        $connection = $this->createMockConnection(
+            $mysqli,
+            [
+                'hostname' => 'localhost',
+                'username' => 'superuser',
+                'password' => '1234',
+                'database' => 'main',
+                'port' => 123,
+                'use_ssl' => true,
+                'driver_options' => [
+                    MYSQLI_CLIENT_SSL_DONT_VERIFY_SERVER_CERT => true
+                ],
+            ]
+        );
+
+        $connection->connect();
+    }
+
     public function testConnectionFails()
     {
         $connection = new Connection([]);
@@ -71,5 +127,64 @@ class ConnectionTest extends TestCase
         $this->expectException('\Laminas\Db\Adapter\Exception\RuntimeException');
         $this->expectExceptionMessage('Connection error');
         $connection->connect();
+    }
+
+    /**
+     * Create a mock mysqli
+     *
+     * @param int $flags Expected flags to real_connect
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function createMockMysqli($flags)
+    {
+        $mysqli = $this->getMockBuilder('\mysqli')->getMock();
+        $mysqli->expects($this->once())
+            ->method('init');
+        $mysqli->expects($flags ? $this->once() : $this->never())
+            ->method('ssl_set')
+            ->with(
+                $this->equalTo(null),
+                $this->equalTo(null),
+                $this->equalTo(null),
+                $this->equalTo(null),
+                $this->equalTo(null)
+            );
+
+        $mysqli->expects($this->once())
+            ->method('real_connect')
+            ->with(
+                $this->equalTo('localhost'),
+                $this->equalTo('superuser'),
+                $this->equalTo('1234'),
+                $this->equalTo('main'),
+                $this->equalTo(123),
+                $this->equalTo(null),
+                $this->equalTo($flags)
+            )
+            ->willReturn(null);
+
+        return $mysqli;
+    }
+
+    /**
+     * Create a mock connection
+     *
+     * @param \PHPUnit\Framework\MockObject\MockObject $mysqli Mock mysqli object
+     * @param array                                    $params Connection params
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function createMockConnection($mysqli, $params)
+    {
+        $connection = $this->getMockBuilder('\Laminas\Db\Adapter\Driver\Mysqli\Connection')
+            ->setMethods(['createResource'])
+            ->setConstructorArgs([$params])
+            ->getMock();
+        $connection->expects($this->once())
+            ->method('createResource')
+            ->willReturn($mysqli);
+
+        return $connection;
     }
 }


### PR DESCRIPTION
…use_ssl is set.

Signed-off-by: Ere Maijala <ere.maijala@helsinki.fi>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This fixes an issue where setting use_ssl to true alone doesn't actually make the connection secure. It is only made secure if any of the client_key, client_cert, ca_cert, ca_path or cipher is also set to a non-empty value.

To reproduce the problem prior to this fix do something like this:

```
use Laminas\Db\Adapter\Adapter;
$adapter = new Adapter(
    [
        'driver' => 'mysqli',
        'hostname' => 'localhost',
        'username' => 'user',
        'password' => 'password',
        'database' => 'test',
        'use_ssl' => true
    ]
);
$statement = $adapter->createStatement("SHOW SESSION STATUS LIKE 'Ssl_cipher'");
foreach ($statement->execute() as $res) {
    print_r($res);
}
```

Expected: a non-empty value for Ssl_cipher
Actual: Ssl_cipher is empty
Tested with: PHP 7.2.20

The patch moves mysqli class creation in the Connection class to a helper method to make it easier to test the class and adds a couple of tests that verify the connection parameters using mock objects. The failed connection test is moved last since it sets connect_error property in mysqli, and I couldn't find a simple way to mock or override it later on (trying to mock the __get method causes a warning with PHPUnit).
