### PR TITLE
fix: allow multi parameters to be a string in SQL instructions

### DIFF
--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -244,6 +244,7 @@ abstract class AbstractSql implements SqlInterface
                         $ppCount = count($multiParamsForPosition);
                     } else {
                         $ppCount = 1;
+                        $multiParamsForPosition = [$multiParamsForPosition];
                     }
 
                     if (! isset($paramSpecs[$position][$ppCount])) {


### PR DESCRIPTION
Signed-off-by: Julien Guittard <julien.guittard@me.com>