### PR TITLE
Fix for MySQL DROP CONSTRAINT (Port of PR#247 on zend-db to laminas-db)

### DIFF
--- a/docs/book/sql-ddl.md
+++ b/docs/book/sql-ddl.md
@@ -104,8 +104,34 @@ $table->changeColumn('name', Column\Varchar('new_name', 50));
 You may also *drop* existing columns or constraints:
 
 ```php
+use \Laminas\Db\Metadata\Object\ConstraintObject;
+
 $table->dropColumn('foo');
-$table->dropConstraint('my_index');
+
+$constraint = new ConstraintObject('my_index', null);
+$table->dropConstraint($constraint);
+```
+
+Notice: On MySQL, you need to specify the type of constraint you want to drop.
+To do so you may use a `\Laminas\Db\Metadata\Object\ConstraintObject` and set its
+type accordingly or directly a subclass of
+`\Laminas\Db\Sql\Ddl\Constraint\ConstraintInterface`.
+
+```php
+use \Laminas\Db\Metadata\Object\ConstraintObject;
+
+$fkConstraint = new ConstraintObject('my_fk', null);
+$fkConstraint->setType('FOREIGN KEY');
+$table->dropConstraint($fkConstraint);
+```
+
+```php
+use \Laminas\Db\Sql\Ddl\Constraint\UniqueKey;
+
+$idxConstraint = new UniqueKey(
+    null, 'my_unique_index'
+);
+$table->dropConstraint($idxConstraint);
 ```
 
 ## Dropping Tables

--- a/src/Sql/Ddl/AlterTable.php
+++ b/src/Sql/Ddl/AlterTable.php
@@ -9,6 +9,7 @@
 namespace Laminas\Db\Sql\Ddl;
 
 use Laminas\Db\Adapter\Platform\PlatformInterface;
+use Laminas\Db\Metadata\Object\ConstraintObject;
 use Laminas\Db\Sql\AbstractSql;
 use Laminas\Db\Sql\TableIdentifier;
 
@@ -27,7 +28,7 @@ class AlterTable extends AbstractSql implements SqlInterface
     protected $addColumns = [];
 
     /**
-     * @var array
+     * @var Constraint\ConstraintInterface[]
      */
     protected $addConstraints = [];
 
@@ -42,7 +43,7 @@ class AlterTable extends AbstractSql implements SqlInterface
     protected $dropColumns = [];
 
     /**
-     * @var array
+     * @var Constraint\ConstraintInterface[]|ConstraintObject[]
      */
     protected $dropConstraints = [];
 
@@ -74,7 +75,7 @@ class AlterTable extends AbstractSql implements SqlInterface
         ],
         self::DROP_CONSTRAINTS  => [
             "%1\$s" => [
-                [1 => "DROP CONSTRAINT %1\$s,\n", 'combinedby' => ""],
+                [1 => "DROP CONSTRAINT %1\$s,\n", 'combinedby' => " "],
             ]
         ]
     ];
@@ -138,12 +139,12 @@ class AlterTable extends AbstractSql implements SqlInterface
     }
 
     /**
-     * @param  string $name
+     * @param  Constraint\ConstraintInterface|ConstraintObject $constraint
      * @return self Provides a fluent interface
      */
-    public function dropConstraint($name)
+    public function dropConstraint($constraint)
     {
-        $this->dropConstraints[] = $name;
+        $this->dropConstraints[] = $constraint;
 
         return $this;
     }
@@ -229,7 +230,7 @@ class AlterTable extends AbstractSql implements SqlInterface
     {
         $sqls = [];
         foreach ($this->dropConstraints as $constraint) {
-            $sqls[] = $adapterPlatform->quoteIdentifier($constraint);
+            $sqls[] = $adapterPlatform->quoteIdentifier($constraint->getName());
         }
 
         return [$sqls];

--- a/src/Sql/Ddl/Constraint/ConstraintInterface.php
+++ b/src/Sql/Ddl/Constraint/ConstraintInterface.php
@@ -13,4 +13,9 @@ use Laminas\Db\Sql\ExpressionInterface;
 interface ConstraintInterface extends ExpressionInterface
 {
     public function getColumns();
+
+    /**
+     * @return string
+     */
+    public function getName();
 }

--- a/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
@@ -9,7 +9,11 @@
 namespace Laminas\Db\Sql\Platform\Mysql\Ddl;
 
 use Laminas\Db\Adapter\Platform\PlatformInterface;
+use Laminas\Db\Metadata\Object\ConstraintObject;
 use Laminas\Db\Sql\Ddl\AlterTable;
+use Laminas\Db\Sql\Ddl\Constraint\ForeignKey;
+use Laminas\Db\Sql\Ddl\Constraint\PrimaryKey;
+use Laminas\Db\Sql\Ddl\Index\AbstractIndex;
 use Laminas\Db\Sql\Platform\PlatformDecoratorInterface;
 
 class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterface
@@ -42,6 +46,11 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
     public function setSubject($subject)
     {
         $this->subject = $subject;
+        $this->subject->specifications[self::DROP_CONSTRAINTS] = [
+            "%1\$s" => [
+                [2 => "DROP %1\$s %2\$s,\n", 'combinedby' => " "],
+            ]
+        ];
 
         return $this;
     }
@@ -246,5 +255,38 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
             ? $this->columnOptionSortOrder[$columnB] : count($this->columnOptionSortOrder);
 
         return $columnA - $columnB;
+    }
+
+    protected function processDropConstraints(PlatformInterface $adapterPlatform = null)
+    {
+        $sqls = [];
+        foreach ($this->dropConstraints as $constraint) {
+            $sqls[] = [
+                $this->getConstraintType($constraint),
+                $adapterPlatform->quoteIdentifier($constraint->getName())
+            ];
+        }
+
+        return [$sqls];
+    }
+
+    /**
+     * @param $constraint
+     * @return string
+     */
+    protected function getConstraintType($constraint)
+    {
+        if ($constraint instanceof ConstraintObject) {
+            return $constraint->getType();
+        }
+        if ($constraint instanceof PrimaryKey) {
+            return 'PRIMARY KEY';
+        } elseif ($constraint instanceof ForeignKey) {
+            return 'FOREIGN KEY';
+        } elseif ($constraint instanceof AbstractIndex) {
+            return 'INDEX';
+        } else {
+            return 'KEY';
+        }
     }
 }

--- a/test/unit/Sql/Ddl/AlterTableTest.php
+++ b/test/unit/Sql/Ddl/AlterTableTest.php
@@ -8,6 +8,7 @@
 
 namespace LaminasTest\Db\Sql\Ddl;
 
+use Laminas\Db\Metadata\Object\ConstraintObject;
 use Laminas\Db\Sql\Ddl\AlterTable;
 use Laminas\Db\Sql\Ddl\Column;
 use Laminas\Db\Sql\Ddl\Constraint;
@@ -94,14 +95,16 @@ class AlterTableTest extends TestCase
         $at->changeColumn('name', new Column\Varchar('new_name', 50));
         $at->dropColumn('foo');
         $at->addConstraint(new Constraint\ForeignKey('my_fk', 'other_id', 'other_table', 'id', 'CASCADE', 'CASCADE'));
-        $at->dropConstraint('my_index');
+        $at->dropConstraint(new ConstraintObject('my_index', null));
+        $at->dropConstraint(new Constraint\UniqueKey(null, 'my_unique_index'));
         $expected = <<<EOS
 ALTER TABLE "foo"
  ADD COLUMN "another" VARCHAR(255) NOT NULL,
  CHANGE COLUMN "name" "new_name" VARCHAR(50) NOT NULL,
  DROP COLUMN "foo",
  ADD CONSTRAINT "my_fk" FOREIGN KEY ("other_id") REFERENCES "other_table" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
- DROP CONSTRAINT "my_index"
+ DROP CONSTRAINT "my_index",
+ DROP CONSTRAINT "my_unique_index"
 EOS;
 
         $actual = $at->getSqlString();

--- a/test/unit/Sql/Platform/Mysql/Ddl/AlterTableDecoratorTest.php
+++ b/test/unit/Sql/Platform/Mysql/Ddl/AlterTableDecoratorTest.php
@@ -9,9 +9,11 @@
 namespace LaminasTest\Db\Sql\Platform\Mysql\Ddl;
 
 use Laminas\Db\Adapter\Platform\Mysql;
+use Laminas\Db\Metadata\Object\ConstraintObject;
 use Laminas\Db\Sql\Ddl\AlterTable;
 use Laminas\Db\Sql\Ddl\Column\Column;
 use Laminas\Db\Sql\Ddl\Constraint\PrimaryKey;
+use Laminas\Db\Sql\Ddl\Constraint\UniqueKey;
 use Laminas\Db\Sql\Platform\Mysql\Ddl\AlterTableDecorator;
 use PHPUnit\Framework\TestCase;
 
@@ -45,9 +47,18 @@ class AlterTableDecoratorTest extends TestCase
         $col->addConstraint(new PrimaryKey());
         $ct->addColumn($col);
 
-        self::assertEquals(
-            "ALTER TABLE `foo`\n ADD COLUMN `bar` INTEGER UNSIGNED ZEROFILL " .
-            "NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'baz' AFTER `bar`",
+        $fk = new ConstraintObject('my_fk', null);
+        $fk->setType('FOREIGN KEY');
+        $ct->dropConstraint($fk);
+
+        $ct->dropConstraint(new UniqueKey(null, 'my_unique_index'));
+
+        $this->assertEquals(
+            "ALTER TABLE `foo`\n"
+            ." ADD COLUMN `bar` INTEGER UNSIGNED ZEROFILL NOT NULL AUTO_INCREMENT PRIMARY KEY COMMENT 'baz'"
+            ." AFTER `bar`,\n"
+            ."    DROP FOREIGN KEY `my_fk`,\n"
+            ." DROP KEY `my_unique_index`",
             @$ctd->getSqlString(new Mysql())
         );
     }


### PR DESCRIPTION
**:warning: Warning: BC break ahead.**

This is just the port of my old PR 247 on zend-db to Laminas: https://github.com/zendframework/zend-db/pull/247

I'm not expecting this branch to be more likely to be merged because of the BC breaks but I needed it now my application has been migrated to Laminas, so why not make it as a new updated PR?

Feel free to discuss it again so maybe we can find a good compromise in a near future.

> :point_up: Again, there's zero improvements over [the latest branch that was proposed for zend-db](https://github.com/zendframework/zend-db/pull/247), just a strict migration to Laminas. Unit tests are OK, and my internal tests seem to be fine. That's all I can say.