### PR TITLE
Add additional integer type support

### DIFF
--- a/docs/book/sql-ddl.md
+++ b/docs/book/sql-ddl.md
@@ -171,12 +171,15 @@ Column (generic) | `$name = null`
 Date             | `$name`
 DateTime         | `$name`
 Decimal          | `$name`, `$precision`, `$scale = null`
+Double           | `$name`, `$digits`, `$decimal`
 Float            | `$name`, `$digits`, `$decimal` (Note: this class is deprecated as of 2.4.0; use Floating instead)
 Floating         | `$name`, `$digits`, `$decimal`
 Integer          | `$name`, `$nullable = false`, `default = null`, `array $options = array()`
+SmallInteger     | `$name`, `$nullable = false`, `$default = null`, `array $options = array()`
 Text             | `$name`, `$length`, `nullable = false`, `$default = null`, `array $options = array()`
 Time             | `$name`
 Timestamp        | `$name`
+TinyInteger      | `$name`, `$nullable = false`, `$default = null`, `array $options = array()`
 Varbinary        | `$name`, `$length`
 Varchar          | `$name`, `$length`
 

--- a/src/Sql/Ddl/Column/Double.php
+++ b/src/Sql/Ddl/Column/Double.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Laminas\Db\Sql\Ddl\Column;
+
+/**
+ * Column representing a DOUBLE type.
+ */
+class Double extends AbstractPrecisionColumn
+{
+    /**
+     * @var string
+     */
+    protected $type = 'DOUBLE';
+}

--- a/src/Sql/Ddl/Column/SmallInteger.php
+++ b/src/Sql/Ddl/Column/SmallInteger.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laminas\Db\Sql\Ddl\Column;
+
+class SmallInteger extends Integer
+{
+    /**
+     * @var string
+     */
+    protected $type = 'SMALLINT';
+}

--- a/src/Sql/Ddl/Column/TinyInteger.php
+++ b/src/Sql/Ddl/Column/TinyInteger.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laminas\Db\Sql\Ddl\Column;
+
+class TinyInteger extends Integer
+{
+    /**
+     * @var string
+     */
+    protected $type = 'TINYINT';
+}

--- a/test/unit/Sql/Ddl/Column/DoubleTest.php
+++ b/test/unit/Sql/Ddl/Column/DoubleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LaminasTest\Db\Sql\Ddl\Column;
+
+use Laminas\Db\Sql\Ddl\Column\Double;
+use PHPUnit\Framework\TestCase;
+
+class DoubleTest extends TestCase
+{
+    /**
+     * @covers \Laminas\Db\Sql\Ddl\Column\Double::getExpressionData
+     */
+    public function testGetExpressionData()
+    {
+        $column = new Double('foo', 10, 5);
+        self::assertEquals(
+            [[
+                '%s %s NOT NULL',
+                ['foo', 'DOUBLE(10,5)'],
+                [$column::TYPE_IDENTIFIER, $column::TYPE_LITERAL],
+            ]],
+            $column->getExpressionData()
+        );
+    }
+}

--- a/test/unit/Sql/Ddl/Column/SmallIntegerTest.php
+++ b/test/unit/Sql/Ddl/Column/SmallIntegerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LaminasTest\Db\Sql\Ddl\Column;
+
+use Laminas\Db\Sql\Ddl\Column\SmallInteger;
+use PHPUnit\Framework\TestCase;
+
+class SmallIntegerTest extends TestCase
+{
+    /**
+     * @covers \Laminas\Db\Sql\Ddl\Column\SmallInteger::__construct
+     */
+    public function testObjectConstruction()
+    {
+        $integer = new SmallInteger('foo');
+        self::assertEquals('foo', $integer->getName());
+    }
+
+    /**
+     * @covers \Laminas\Db\Sql\Ddl\Column\Column::getExpressionData
+     */
+    public function testGetExpressionData()
+    {
+        $column = new SmallInteger('foo');
+        self::assertEquals(
+            [['%s %s NOT NULL', ['foo', 'SMALLINT'], [$column::TYPE_IDENTIFIER, $column::TYPE_LITERAL]]],
+            $column->getExpressionData()
+        );
+    }
+}

--- a/test/unit/Sql/Ddl/Column/TinyIntegerTest.php
+++ b/test/unit/Sql/Ddl/Column/TinyIntegerTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LaminasTest\Db\Sql\Ddl\Column;
+
+use Laminas\Db\Sql\Ddl\Column\TinyInteger;
+use PHPUnit\Framework\TestCase;
+
+class TinyIntegerTest extends TestCase
+{
+    /**
+     * @covers \Laminas\Db\Sql\Ddl\Column\SmallInteger::__construct
+     */
+    public function testObjectConstruction()
+    {
+        $integer = new TinyInteger('foo');
+        self::assertEquals('foo', $integer->getName());
+    }
+
+    /**
+     * @covers \Laminas\Db\Sql\Ddl\Column\Column::getExpressionData
+     */
+    public function testGetExpressionData()
+    {
+        $column = new TinyInteger('foo');
+        self::assertEquals(
+            [['%s %s NOT NULL', ['foo', 'TINYINT'], [$column::TYPE_IDENTIFIER, $column::TYPE_LITERAL]]],
+            $column->getExpressionData()
+        );
+    }
+}


### PR DESCRIPTION
Add support for Double, Small Integer and Tiny Integer data types. These data types have been supported in both MS SQL and MySQL for some time and are missing from this component.