### PR TITLE
Add DDL drop indexes

### DIFF
--- a/src/Sql/Ddl/AlterTable.php
+++ b/src/Sql/Ddl/AlterTable.php
@@ -15,6 +15,7 @@ class AlterTable extends AbstractSql implements SqlInterface
     public const CHANGE_COLUMNS   = 'changeColumns';
     public const DROP_COLUMNS     = 'dropColumns';
     public const DROP_CONSTRAINTS = 'dropConstraints';
+    public const DROP_INDEXES     = 'dropIndexes';
     public const TABLE            = 'table';
 
     /** @var array */
@@ -31,6 +32,9 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /** @var array */
     protected $dropConstraints = [];
+
+    /** @var array */
+    protected $dropIndexes = [];
 
     /**
      * Specifications for Sql String generation
@@ -62,6 +66,11 @@ class AlterTable extends AbstractSql implements SqlInterface
         self::DROP_CONSTRAINTS => [
             "%1\$s" => [
                 [1 => "DROP CONSTRAINT %1\$s,\n", 'combinedby' => ""],
+            ],
+        ],
+        self::DROP_INDEXES     => [
+            '%1$s' => [
+                [1 => "DROP INDEX %1\$s,\n", 'combinedby' => ''],
             ],
         ],
     ];
@@ -142,6 +151,17 @@ class AlterTable extends AbstractSql implements SqlInterface
     }
 
     /**
+     * @param  string $name
+     * @return self Provides a fluent interface
+     */
+    public function dropIndex($name)
+    {
+        $this->dropIndexes[] = $name;
+
+        return $this;
+    }
+
+    /**
      * @param  string|null $key
      * @return array
      */
@@ -154,6 +174,7 @@ class AlterTable extends AbstractSql implements SqlInterface
             self::CHANGE_COLUMNS   => $this->changeColumns,
             self::ADD_CONSTRAINTS  => $this->addConstraints,
             self::DROP_CONSTRAINTS => $this->dropConstraints,
+            self::DROP_INDEXES     => $this->dropIndexes,
         ];
 
         return isset($key) && array_key_exists($key, $rawState) ? $rawState[$key] : $rawState;
@@ -218,6 +239,17 @@ class AlterTable extends AbstractSql implements SqlInterface
         $sqls = [];
         foreach ($this->dropConstraints as $constraint) {
             $sqls[] = $adapterPlatform->quoteIdentifier($constraint);
+        }
+
+        return [$sqls];
+    }
+
+    /** @return string[] */
+    protected function processDropIndexes(?PlatformInterface $adapterPlatform = null)
+    {
+        $sqls = [];
+        foreach ($this->dropIndexes as $index) {
+            $sqls[] = $adapterPlatform->quoteIdentifier($index);
         }
 
         return [$sqls];

--- a/test/unit/Sql/Ddl/AlterTableTest.php
+++ b/test/unit/Sql/Ddl/AlterTableTest.php
@@ -82,6 +82,16 @@ class AlterTableTest extends TestCase
     }
 
     /**
+     * @covers \Laminas\Db\Sql\Ddl\AlterTable::dropIndex
+     */
+    public function testDropIndex()
+    {
+        $at = new AlterTable();
+        self::assertSame($at, $at->dropIndex('foo'));
+        self::assertEquals(['foo'], $at->getRawState($at::DROP_INDEXES));
+    }
+
+    /**
      * @covers \Laminas\Db\Sql\Ddl\AlterTable::getSqlString
      * @todo   Implement testGetSqlString().
      */
@@ -92,14 +102,16 @@ class AlterTableTest extends TestCase
         $at->changeColumn('name', new Column\Varchar('new_name', 50));
         $at->dropColumn('foo');
         $at->addConstraint(new Constraint\ForeignKey('my_fk', 'other_id', 'other_table', 'id', 'CASCADE', 'CASCADE'));
-        $at->dropConstraint('my_index');
+        $at->dropConstraint('my_constraint');
+        $at->dropIndex('my_index');
         $expected = <<<EOS
 ALTER TABLE "foo"
  ADD COLUMN "another" VARCHAR(255) NOT NULL,
  CHANGE COLUMN "name" "new_name" VARCHAR(50) NOT NULL,
  DROP COLUMN "foo",
  ADD CONSTRAINT "my_fk" FOREIGN KEY ("other_id") REFERENCES "other_table" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
- DROP CONSTRAINT "my_index"
+ DROP CONSTRAINT "my_constraint"
+ DROP INDEX "my_index"
 EOS;
 
         $actual = $at->getSqlString();

--- a/test/unit/Sql/Ddl/AlterTableTest.php
+++ b/test/unit/Sql/Ddl/AlterTableTest.php
@@ -110,7 +110,7 @@ ALTER TABLE "foo"
  CHANGE COLUMN "name" "new_name" VARCHAR(50) NOT NULL,
  DROP COLUMN "foo",
  ADD CONSTRAINT "my_fk" FOREIGN KEY ("other_id") REFERENCES "other_table" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
- DROP CONSTRAINT "my_constraint"
+ DROP CONSTRAINT "my_constraint",
  DROP INDEX "my_index"
 EOS;
 


### PR DESCRIPTION
DROP CONSTRAINT doesn't successfully drop indexes with Amazon Aurora. Change to DROP INDEX syntax as this is supported and functions as intended
