### PR TITLE
MysqlMetadata Enhancements

### DIFF
--- a/src/Metadata/Object/ColumnObject.php
+++ b/src/Metadata/Object/ColumnObject.php
@@ -83,6 +83,18 @@ class ColumnObject
     protected $errata = [];
 
     /**
+     *
+     * @var string
+     */
+    protected $column_key = null;
+
+    /**
+     *
+     * @var string
+     */
+    protected $extra = null;
+
+    /**
      * Constructor
      *
      * @param string $name
@@ -376,6 +388,42 @@ class ColumnObject
     public function setErrata($errataName, $errataValue)
     {
         $this->errata[$errataName] = $errataValue;
+        return $this;
+    }
+
+    /**
+     * @return null|string the $columnKey
+     */
+    public function getColumnKey()
+    {
+        return $this->column_key;
+    }
+
+    /**
+     * @param string $columnKey the $columnKey to set
+     * @return self Provides a fluent interface
+     */
+    public function setColumnKey($columnKey)
+    {
+        $this->column_key = $columnKey;
+        return $this;
+    }
+
+    /**
+     * @return null|string the $extra
+     */
+    public function getExtra()
+    {
+        return $this->extra;
+    }
+
+    /**
+     * @param string $extra the $extra to set
+     * @return self Provides a fluent interface
+     */
+    public function setExtra($extra)
+    {
+        $this->extra = $extra;
         return $this;
     }
 }

--- a/src/Metadata/Source/AbstractSource.php
+++ b/src/Metadata/Source/AbstractSource.php
@@ -243,7 +243,7 @@ abstract class AbstractSource implements MetadataInterface
             'ordinal_position', 'column_default', 'is_nullable',
             'data_type', 'character_maximum_length', 'character_octet_length',
             'numeric_precision', 'numeric_scale', 'numeric_unsigned',
-            'erratas'
+            'erratas', 'column_key', 'extra'
         ];
         foreach ($props as $prop) {
             if (isset($info[$prop])) {
@@ -261,6 +261,8 @@ abstract class AbstractSource implements MetadataInterface
         $column->setNumericScale($info['numeric_scale']);
         $column->setNumericUnsigned($info['numeric_unsigned']);
         $column->setErratas($info['erratas']);
+        $column->setColumnKey($info['column_key']);
+        $column->setExtra($info['extra']);
 
         return $column;
     }


### PR DESCRIPTION
Add support for column_key and extra fields in MysqlMetadata.

Removes the strange formatting of the names of constraints that aren't foreign keys. I'm unsure why that's ever been a thing, as it doesn't make much sense adding _laminas_{table name} to them?

Wraps the constraint array in a non-null check to prevent a possible null pointer exception

Converts a couple of closures to static functions for better scoping and potential performance improvements