### PR TITLE
Ensure `null` is never used as an exception code

### DIFF
--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -316,7 +316,7 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
         }
 
         if (! isset($driver) || ! $driver instanceof Driver\DriverInterface) {
-            throw new Exception\InvalidArgumentException('DriverInterface expected', null, null);
+            throw new Exception\InvalidArgumentException('DriverInterface expected');
         }
 
         return $driver;

--- a/src/Adapter/Driver/Mysqli/Statement.php
+++ b/src/Adapter/Driver/Mysqli/Statement.php
@@ -188,7 +188,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
         if (! $this->resource instanceof mysqli_stmt) {
             throw new Exception\InvalidQueryException(
                 'Statement couldn\'t be produced with sql: ' . $sql,
-                null,
+                $this->mysqli->errno,
                 new Exception\ErrorException($this->mysqli->error, $this->mysqli->errno)
             );
         }

--- a/src/Adapter/Driver/Oci8/Connection.php
+++ b/src/Adapter/Driver/Oci8/Connection.php
@@ -129,7 +129,7 @@ class Connection extends AbstractConnection
             $e = oci_error();
             throw new Exception\RuntimeException(
                 'Connection error',
-                null,
+                $e['code'],
                 new Exception\ErrorException($e['message'], $e['code'])
             );
         }

--- a/src/Adapter/Driver/Oci8/Statement.php
+++ b/src/Adapter/Driver/Oci8/Statement.php
@@ -184,7 +184,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
             $e = oci_error($this->oci8);
             throw new Exception\InvalidQueryException(
                 'Statement couldn\'t be produced with sql: ' . $sql,
-                null,
+                $e['code'],
                 new Exception\ErrorException($e['message'], $e['code'])
             );
         }

--- a/src/Adapter/Driver/Sqlsrv/Connection.php
+++ b/src/Adapter/Driver/Sqlsrv/Connection.php
@@ -135,7 +135,7 @@ class Connection extends AbstractConnection
         if (! $this->resource) {
             throw new Exception\RuntimeException(
                 'Connect Error',
-                null,
+                0,
                 new ErrorException(sqlsrv_errors())
             );
         }


### PR DESCRIPTION
PHP 8.1 deprecates using `null` as an exception code. This patch picks up a few additional cases where this was occurring that were missed in #205 (thanks, @boesing, for pointing this out!).
