### PR TITLE
Ensure that each `Adapter#query()` call produces a new `ResultSet`

### DIFF
--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -195,9 +195,12 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
         }
 
         if ($result instanceof Driver\ResultInterface && $result->isQueryResult()) {
-            $resultSet = $resultPrototype !== null ? clone $resultPrototype : $this->queryResultSetPrototype;
-            $resultSet->initialize($result);
-            return $resultSet;
+            $resultSet     = $resultPrototype ?? $this->queryResultSetPrototype;
+            $resultSetCopy = clone $resultSet;
+
+            $resultSetCopy->initialize($result);
+
+            return $resultSetCopy;
         }
 
         return $result;


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes #210

In release 2.13.0, and specifically through 586fea1bee0c573944fe798cf667ee979524d993,
the CS automation introduced a regression that removed a `clone` call from our sources:
https://github.com/laminas/laminas-db/commit/586fea1bee0c573944fe798cf667ee979524d993#diff-55955428038b9bf948e0383865ab55ceee44aabe8418040d92e9b78814064b0fR198

This `clone` call is vital, as it binds separate `ResultSet` objects to separate statements.

This change led to the regression explained by @rutek in #210, where two separate queries
would lead to same `ResultSet` instances, and therefore to incorrect results (and iterator
rewind on non-rewindable operator too, as a side-effect)
