### PR TITLE
Recognize pgsql resource objects when running in PHP 8.1

### DIFF
--- a/src/Adapter/Driver/Pgsql/Connection.php
+++ b/src/Adapter/Driver/Pgsql/Connection.php
@@ -5,6 +5,7 @@ namespace Laminas\Db\Adapter\Driver\Pgsql;
 use Laminas\Db\Adapter\Driver\AbstractConnection;
 use Laminas\Db\Adapter\Exception;
 use Laminas\Db\ResultSet\ResultSetInterface;
+use PgSql\Connection as PgSqlConnection;
 
 use function array_filter;
 use function defined;
@@ -45,7 +46,7 @@ class Connection extends AbstractConnection
     {
         if (is_array($connectionInfo)) {
             $this->setConnectionParameters($connectionInfo);
-        } elseif (is_resource($connectionInfo)) {
+        } elseif ($connectionInfo instanceof PgSqlConnection || is_resource($connectionInfo)) {
             $this->setResource($connectionInfo);
         }
     }
@@ -123,7 +124,7 @@ class Connection extends AbstractConnection
      */
     public function connect()
     {
-        if (is_resource($this->resource)) {
+        if ($this->resource instanceof PgSqlConnection || is_resource($this->resource)) {
             return $this;
         }
 
@@ -168,7 +169,7 @@ class Connection extends AbstractConnection
      */
     public function isConnected()
     {
-        return is_resource($this->resource);
+        return $this->resource instanceof PgSqlConnection || is_resource($this->resource);
     }
 
     /**

--- a/src/Adapter/Driver/Pgsql/Result.php
+++ b/src/Adapter/Driver/Pgsql/Result.php
@@ -4,6 +4,7 @@ namespace Laminas\Db\Adapter\Driver\Pgsql;
 
 use Laminas\Db\Adapter\Driver\ResultInterface;
 use Laminas\Db\Adapter\Exception;
+use PgSql\Result as PgSqlResult;
 // phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 use ReturnTypeWillChange;
 
@@ -38,7 +39,13 @@ class Result implements ResultInterface
      */
     public function initialize($resource, $generatedValue)
     {
-        if (! is_resource($resource) || get_resource_type($resource) !== 'pgsql result') {
+        if (
+            ! $resource instanceof PgSqlResult
+            && (
+                ! is_resource($resource)
+                || 'pgsql result' !== get_resource_type($resource)
+            )
+        ) {
             throw new Exception\InvalidArgumentException('Resource not of the correct type.');
         }
 

--- a/src/Adapter/Driver/Pgsql/Statement.php
+++ b/src/Adapter/Driver/Pgsql/Statement.php
@@ -6,6 +6,7 @@ use Laminas\Db\Adapter\Driver\StatementInterface;
 use Laminas\Db\Adapter\Exception;
 use Laminas\Db\Adapter\ParameterContainer;
 use Laminas\Db\Adapter\Profiler;
+use PgSql\Connection as PgSqlConnection;
 
 use function get_resource_type;
 use function is_array;
@@ -77,7 +78,13 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      */
     public function initialize($pgsql)
     {
-        if (! is_resource($pgsql) || get_resource_type($pgsql) !== 'pgsql link') {
+        if (
+            ! $pgsql instanceof PgSqlConnection
+            && (
+                ! is_resource($pgsql)
+                || 'pgsql link' !== get_resource_type($pgsql)
+            )
+        ) {
             throw new Exception\RuntimeException(sprintf(
                 '%s: Invalid or missing postgresql connection; received "%s"',
                 __METHOD__,

--- a/src/Adapter/Platform/Postgresql.php
+++ b/src/Adapter/Platform/Postgresql.php
@@ -10,6 +10,7 @@ use PgSql\Connection as PgSqlConnection;
 
 use function get_resource_type;
 use function implode;
+use function in_array;
 use function is_resource;
 use function pg_escape_string;
 use function str_replace;

--- a/src/Adapter/Platform/Postgresql.php
+++ b/src/Adapter/Platform/Postgresql.php
@@ -6,10 +6,10 @@ use Laminas\Db\Adapter\Driver\DriverInterface;
 use Laminas\Db\Adapter\Driver\Pdo;
 use Laminas\Db\Adapter\Driver\Pgsql;
 use Laminas\Db\Adapter\Exception;
+use PgSql\Connection as PgSqlConnection;
 
 use function get_resource_type;
 use function implode;
-use function in_array;
 use function is_resource;
 use function pg_escape_string;
 use function str_replace;
@@ -25,6 +25,12 @@ class Postgresql extends AbstractPlatform
 
     /** @var null|resource|\PDO|Pdo\Pdo|Pgsql\Pgsql */
     protected $driver;
+
+    /** @var string[] */
+    private $knownPgsqlResources = [
+        'pgsql link',
+        'pgsql link persistent',
+    ];
 
     /**
      * @param null|\Laminas\Db\Adapter\Driver\Pgsql\Pgsql|\Laminas\Db\Adapter\Driver\Pdo\Pdo|resource|\PDO $driver
@@ -46,7 +52,8 @@ class Postgresql extends AbstractPlatform
         if (
             $driver instanceof Pgsql\Pgsql
             || ($driver instanceof Pdo\Pdo && $driver->getDatabasePlatformName() === 'Postgresql')
-            || (is_resource($driver) && (in_array(get_resource_type($driver), ['pgsql link', 'pgsql link persistent'])))
+            || $driver instanceof PgSqlConnection // PHP 8.1+
+            || (is_resource($driver) && in_array(get_resource_type($driver), $this->knownPgsqlResources, true))
             || ($driver instanceof \PDO && $driver->getAttribute(\PDO::ATTR_DRIVER_NAME) === 'pgsql')
         ) {
             $this->driver = $driver;
@@ -108,15 +115,14 @@ class Postgresql extends AbstractPlatform
      */
     protected function quoteViaDriver($value)
     {
-        if ($this->driver instanceof DriverInterface) {
-            $resource = $this->driver->getConnection()->getResource();
-        } else {
-            $resource = $this->driver;
-        }
+        $resource = $this->driver instanceof DriverInterface
+            ? $this->driver->getConnection()->getResource()
+            : $this->driver;
 
-        if (is_resource($resource)) {
+        if ($resource instanceof PgSqlConnection || is_resource($resource)) {
             return '\'' . pg_escape_string($resource, $value) . '\'';
         }
+
         if ($resource instanceof \PDO) {
             return $resource->quote($value);
         }

--- a/test/integration/Adapter/Platform/PostgresqlTest.php
+++ b/test/integration/Adapter/Platform/PostgresqlTest.php
@@ -5,6 +5,7 @@ namespace LaminasIntegrationTest\Db\Adapter\Platform;
 use Laminas\Db\Adapter\Driver\Pdo;
 use Laminas\Db\Adapter\Driver\Pgsql;
 use Laminas\Db\Adapter\Platform\Postgresql;
+use PgSql\Connection as PgSqlConnection;
 use PHPUnit\Framework\TestCase;
 
 use function extension_loaded;
@@ -46,7 +47,13 @@ class PostgresqlTest extends TestCase
 
     public function testQuoteValueWithPgsql()
     {
-        if (! is_resource($this->adapters['pgsql'])) {
+        if (
+            ! isset($this->adapters['pgsql'])
+            || (
+                ! $this->adapters['pgsql'] instanceof PgSqlConnection
+                && ! is_resource($this->adapters['pgsql'])
+            )
+        ) {
             $this->markTestSkipped('Postgres (pgsql) not configured in unit test configuration file');
         }
         $pgsql = new Postgresql($this->adapters['pgsql']);
@@ -60,7 +67,7 @@ class PostgresqlTest extends TestCase
 
     public function testQuoteValueWithPdoPgsql()
     {
-        if (! $this->adapters['pdo_pgsql'] instanceof \PDO) {
+        if (! isset($this->adapters['pdo_pgsql']) || ! $this->adapters['pdo_pgsql'] instanceof \PDO) {
             $this->markTestSkipped('Postgres (PDO_PGSQL) not configured in unit test configuration file');
         }
         $pgsql = new Postgresql($this->adapters['pdo_pgsql']);


### PR DESCRIPTION
Per:

- https://github.com/php/php-src/pull/6791
- https://github.com/php/php-src/blob/a846547ed4bb67f00dc12bbfc529e9c992cbfd07/UPGRADING

The pgsql functions now accept and return **resource objects** and not **resources**. As such, the return value of `get_resource_type()` varies, and technically, in PHP 8.1, we should not use `is_resource()`, but a typecheck instead. However, we still need to support pre-8.1 code as well.
