### PR TITLE
MySQL and MSQL fixtures now recreate test structure.

### DIFF
--- a/test/integration/TestFixtures/mysql.sql
+++ b/test/integration/TestFixtures/mysql.sql
@@ -1,4 +1,5 @@
-CREATE TABLE IF NOT EXISTS test (
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (
     id INT NOT NULL AUTO_INCREMENT,
     name VARCHAR(255) NOT NULL,
     value VARCHAR(255) NOT NULL,
@@ -11,7 +12,8 @@ INSERT INTO test (name, value) VALUES
 ('123a', 'bar'),
 ('123', 'bar');
 
-CREATE TABLE IF NOT EXISTS test_charset (
+DROP TABLE IF EXISTS test_charset;
+CREATE TABLE test_charset (
     id INT NOT NULL AUTO_INCREMENT,
     field$ VARCHAR(255) NOT NULL,
     field_ VARCHAR(255) NOT NULL,
@@ -22,6 +24,7 @@ INSERT INTO test_charset (field$, field_) VALUES
 ('foo', 'bar'),
 ('bar', 'baz');
 
+DROP TABLE IF EXISTS test_audit_trail;
 CREATE TABLE test_audit_trail (
     id INT NOT NULL AUTO_INCREMENT,
     test_id INT NOT NULL,
@@ -31,6 +34,7 @@ CREATE TABLE test_audit_trail (
     PRIMARY KEY (id)
 );
 
+DROP VIEW IF EXISTS test_view;
 CREATE VIEW test_view
 AS
 SELECT
@@ -39,6 +43,7 @@ SELECT
 FROM
     test;
 
+DROP TRIGGER IF EXISTS after_test_update;
 CREATE TRIGGER after_test_update
     AFTER UPDATE ON test
     FOR EACH ROW

--- a/test/integration/TestFixtures/sqlsrv-triggers.sql
+++ b/test/integration/TestFixtures/sqlsrv-triggers.sql
@@ -1,4 +1,4 @@
-CREATE TRIGGER after_test_update ON test
+CREATE OR ALTER TRIGGER after_test_update ON test
     AFTER UPDATE
     AS
 BEGIN

--- a/test/integration/TestFixtures/sqlsrv-views.sql
+++ b/test/integration/TestFixtures/sqlsrv-views.sql
@@ -1,4 +1,4 @@
-CREATE VIEW test_view
+CREATE OR ALTER VIEW test_view
 AS (
 SELECT
     name AS v_name,

--- a/test/integration/TestFixtures/sqlsrv.sql
+++ b/test/integration/TestFixtures/sqlsrv.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS test;
 CREATE TABLE test (
                       id INT NOT NULL IDENTITY,
                       name VARCHAR(255) NOT NULL,
@@ -11,6 +12,7 @@ INSERT INTO test (name, value) VALUES
 ('123a', 'bar'),
 ('123', 'bar');
 
+DROP TABLE IF EXISTS test_charset;
 CREATE TABLE test_charset (
                               id INT NOT NULL IDENTITY,
                               field$ VARCHAR(255) NOT NULL,
@@ -22,6 +24,7 @@ INSERT INTO test_charset (field$, field_) VALUES
 ('foo', 'bar'),
 ('bar', 'baz');
 
+DROP TABLE IF EXISTS test_audit_trail
 CREATE TABLE test_audit_trail (
                                   id INT NOT NULL IDENTITY,
                                   test_id INT NOT NULL,


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

All time, when we run tests we need reset VirtualBox to init state.
This commit recreate tested structure for MySQL and MSSQL.
So, we can run tests without rollback VirtualBox image - it's spend save time.

If we run integradion test two time, we got an error
```TEXT
phpunit --colors=always --testsuite "integration test"
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.


Integration test started.
.....FFF...................SSS..SSSS                              36 / 36 (100%)

Time: 00:03.583, Memory: 10.00 MB

There were 3 failures:

1) LaminasIntegrationTest\Db\Adapter\Driver\Pdo\Mysql\QueryTest::testQuery with data set #0 ('SELECT * FROM test WHERE id = ?', array(1), array(1, 'foo', 'bar'))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'id' => 1
-    'name' => 'foo'
-    'value' => 'bar'
+    'id' => '1'
+    'name' => 'bar'
+    'value' => 'foo'
 )

/app/test/integration/Adapter/Driver/Pdo/Mysql/QueryTest.php:52

2) LaminasIntegrationTest\Db\Adapter\Driver\Pdo\Mysql\QueryTest::testQuery with data set #1 ('SELECT * FROM test WHERE id = :id', array(1), array(1, 'foo', 'bar'))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'id' => 1
-    'name' => 'foo'
-    'value' => 'bar'
+    'id' => '1'
+    'name' => 'bar'
+    'value' => 'foo'
 )

/app/test/integration/Adapter/Driver/Pdo/Mysql/QueryTest.php:52

3) LaminasIntegrationTest\Db\Adapter\Driver\Pdo\Mysql\QueryTest::testQuery with data set #2 ('SELECT * FROM test WHERE id = :id', array(1), array(1, 'foo', 'bar'))
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'id' => 1
-    'name' => 'foo'
-    'value' => 'bar'
+    'id' => '1'
+    'name' => 'bar'
+    'value' => 'foo'
 )

/app/test/integration/Adapter/Driver/Pdo/Mysql/QueryTest.php:52

```

@TODO: Do it for PostgreSQL, SQLite and other databases.