### PR TITLE
Fix `Laminas\Db\Adapter\Driver\Mysqli\Connection::__construct($connectionInfo)` type declaration to respect FQCN references

### DIFF
--- a/src/Adapter/Driver/Mysqli/Connection.php
+++ b/src/Adapter/Driver/Mysqli/Connection.php
@@ -27,7 +27,7 @@ class Connection extends AbstractConnection
     /**
      * Constructor
      *
-     * @param array|mysqli|null $connectionInfo
+     * @param array|\mysqli|null $connectionInfo
      * @throws InvalidArgumentException
      */
     public function __construct($connectionInfo = null)


### PR DESCRIPTION
Currently, "mysqli" is interpreted as belonging to the class's namespace which leads to errors with static analysis (e.g. PHPStan) when passing a \mysqli object

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no