### PR TITLE
Fix dockblock for where/having methods in Select, Delete, Update 

### DIFF
--- a/src/Sql/Delete.php
+++ b/src/Sql/Delete.php
@@ -6,6 +6,7 @@ use Closure;
 use Laminas\Db\Adapter\Driver\DriverInterface;
 use Laminas\Db\Adapter\ParameterContainer;
 use Laminas\Db\Adapter\Platform\PlatformInterface;
+use Laminas\Db\Sql\Predicate\PredicateInterface;
 
 use function array_key_exists;
 use function sprintf;
@@ -86,7 +87,7 @@ class Delete extends AbstractPreparableSql
     /**
      * Create where clause
      *
-     * @param Where|Closure|string|array $predicate
+     * @param Where|Closure|string|array|PredicateInterface $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
      * @return $this Provides a fluent interface
      */

--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -6,6 +6,7 @@ use Closure;
 use Laminas\Db\Adapter\Driver\DriverInterface;
 use Laminas\Db\Adapter\ParameterContainer;
 use Laminas\Db\Adapter\Platform\PlatformInterface;
+use Laminas\Db\Sql\Predicate\PredicateInterface;
 
 use function array_key_exists;
 use function count;
@@ -268,7 +269,7 @@ class Select extends AbstractPreparableSql
     /**
      * Create where clause
      *
-     * @param Where|Closure|string|array|Predicate\PredicateInterface $predicate
+     * @param Where|Closure|string|array|PredicateInterface $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
      * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
@@ -302,7 +303,7 @@ class Select extends AbstractPreparableSql
     /**
      * Create having clause
      *
-     * @param Where|Having|Closure|string|array $predicate
+     * @param Having|Closure|string|array|PredicateInterface $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
      * @return $this Provides a fluent interface
      */

--- a/src/Sql/Update.php
+++ b/src/Sql/Update.php
@@ -7,6 +7,7 @@ use Laminas\Db\Adapter\Driver\DriverInterface;
 use Laminas\Db\Adapter\Driver\Pdo\Pdo;
 use Laminas\Db\Adapter\ParameterContainer;
 use Laminas\Db\Adapter\Platform\PlatformInterface;
+use Laminas\Db\Sql\Predicate\PredicateInterface;
 use Laminas\Stdlib\PriorityList;
 
 use function array_key_exists;
@@ -115,7 +116,7 @@ class Update extends AbstractPreparableSql
     /**
      * Create where clause
      *
-     * @param Where|Closure|string|array $predicate
+     * @param Where|Closure|string|array|PredicateInterface $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
      * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Add missing type `Predicate\PredicateInterface` to the docblocks in `Sql\Delete::where()`,  `Sql\Select::where()`,  `Sql\Select::having()` and  `Sql\Update::where()`. This will fix phpstan failures.
