### PR TITLE
Adjust documented return types to be `$this` where the pre-existing `self` declaration was too imprecise 

### DIFF
--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -93,7 +93,7 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {

--- a/src/Adapter/AdapterAwareTrait.php
+++ b/src/Adapter/AdapterAwareTrait.php
@@ -10,7 +10,7 @@ trait AdapterAwareTrait
     /**
      * Set db adapter
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDbAdapter(Adapter $adapter)
     {

--- a/src/Adapter/Driver/AbstractConnection.php
+++ b/src/Adapter/Driver/AbstractConnection.php
@@ -95,7 +95,7 @@ abstract class AbstractConnection implements ConnectionInterface, ProfilerAwareI
 
     /**
      * @param  array $connectionParameters
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setConnectionParameters(array $connectionParameters)
     {
@@ -107,7 +107,7 @@ abstract class AbstractConnection implements ConnectionInterface, ProfilerAwareI
     /**
      * {@inheritDoc}
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(ProfilerInterface $profiler)
     {

--- a/src/Adapter/Driver/IbmDb2/Connection.php
+++ b/src/Adapter/Driver/IbmDb2/Connection.php
@@ -57,7 +57,7 @@ class Connection extends AbstractConnection
     /**
      * Set driver
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver(IbmDb2 $driver)
     {
@@ -68,7 +68,7 @@ class Connection extends AbstractConnection
 
     /**
      * @param  resource $resource DB2 resource
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setResource($resource)
     {
@@ -204,7 +204,7 @@ class Connection extends AbstractConnection
     /**
      * Rollback
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\RuntimeException
      */
     public function rollback()

--- a/src/Adapter/Driver/IbmDb2/IbmDb2.php
+++ b/src/Adapter/Driver/IbmDb2/IbmDb2.php
@@ -40,7 +40,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -63,7 +63,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -73,7 +73,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statementPrototype)
     {
@@ -83,7 +83,7 @@ class IbmDb2 implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerResultPrototype(Result $resultPrototype)
     {

--- a/src/Adapter/Driver/IbmDb2/Result.php
+++ b/src/Adapter/Driver/IbmDb2/Result.php
@@ -27,7 +27,7 @@ class Result implements ResultInterface
     /**
      * @param  resource $resource
      * @param  mixed $generatedValue
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function initialize($resource, $generatedValue = null)
     {

--- a/src/Adapter/Driver/IbmDb2/Statement.php
+++ b/src/Adapter/Driver/IbmDb2/Statement.php
@@ -42,7 +42,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param resource $resource
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function initialize($resource)
     {
@@ -51,7 +51,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver(IbmDb2 $driver)
     {
@@ -60,7 +60,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -80,7 +80,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param null|string $sql
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -101,7 +101,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Set parameter container
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -145,7 +145,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Prepare sql
      *
      * @param string|null $sql
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\RuntimeException
      */
     public function prepare($sql = null)

--- a/src/Adapter/Driver/Mysqli/Connection.php
+++ b/src/Adapter/Driver/Mysqli/Connection.php
@@ -44,7 +44,7 @@ class Connection extends AbstractConnection
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver(Mysqli $driver)
     {
@@ -71,7 +71,7 @@ class Connection extends AbstractConnection
     /**
      * Set resource
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setResource(\mysqli $resource)
     {

--- a/src/Adapter/Driver/Mysqli/Mysqli.php
+++ b/src/Adapter/Driver/Mysqli/Mysqli.php
@@ -55,7 +55,7 @@ class Mysqli implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -80,7 +80,7 @@ class Mysqli implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Register connection
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {

--- a/src/Adapter/Driver/Mysqli/Result.php
+++ b/src/Adapter/Driver/Mysqli/Result.php
@@ -64,7 +64,7 @@ class Result implements
      * @param mixed $resource
      * @param mixed $generatedValue
      * @param bool|null $isBuffered
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function initialize($resource, $generatedValue, $isBuffered = null)

--- a/src/Adapter/Driver/Mysqli/Statement.php
+++ b/src/Adapter/Driver/Mysqli/Statement.php
@@ -57,7 +57,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Set driver
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver(Mysqli $driver)
     {
@@ -66,7 +66,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -85,7 +85,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Initialize
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function initialize(\mysqli $mysqli)
     {
@@ -97,7 +97,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param  string $sql
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -108,7 +108,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Set Parameter container
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -129,7 +129,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Set resource
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setResource(mysqli_stmt $mysqliStatement)
     {
@@ -172,7 +172,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Prepare
      *
      * @param string $sql
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidQueryException
      * @throws Exception\RuntimeException
      */

--- a/src/Adapter/Driver/Oci8/Connection.php
+++ b/src/Adapter/Driver/Oci8/Connection.php
@@ -35,7 +35,7 @@ class Connection extends AbstractConnection
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver(Oci8 $driver)
     {
@@ -65,7 +65,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param  resource $resource
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setResource($resource)
     {

--- a/src/Adapter/Driver/Oci8/Oci8.php
+++ b/src/Adapter/Driver/Oci8/Oci8.php
@@ -69,7 +69,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -94,7 +94,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Register connection
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -106,7 +106,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Register statement prototype
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statementPrototype)
     {
@@ -126,7 +126,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Register result prototype
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerResultPrototype(Result $resultPrototype)
     {
@@ -147,7 +147,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
      *
      * @param string $name
      * @param AbstractFeature $feature
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addFeature($name, $feature)
     {
@@ -162,7 +162,7 @@ class Oci8 implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Setup the default features for Pdo
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setupDefaultFeatures()
     {

--- a/src/Adapter/Driver/Oci8/Result.php
+++ b/src/Adapter/Driver/Oci8/Result.php
@@ -58,7 +58,7 @@ class Result implements Iterator, ResultInterface
      * @param resource $resource
      * @param null|int $generatedValue
      * @param null|int $rowCount
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function initialize($resource, $generatedValue = null, $rowCount = null)
     {

--- a/src/Adapter/Driver/Oci8/Statement.php
+++ b/src/Adapter/Driver/Oci8/Statement.php
@@ -49,7 +49,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set driver
      *
      * @param  Oci8 $driver
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver($driver)
     {
@@ -58,7 +58,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -78,7 +78,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Initialize
      *
      * @param  resource $oci8
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function initialize($oci8)
     {
@@ -90,7 +90,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param  string $sql
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -101,7 +101,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Set Parameter container
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -123,7 +123,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set resource
      *
      * @param  resource $oci8Statement
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setResource($oci8Statement)
     {
@@ -167,7 +167,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param string $sql
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function prepare($sql = null)
     {

--- a/src/Adapter/Driver/Pdo/Connection.php
+++ b/src/Adapter/Driver/Pdo/Connection.php
@@ -50,7 +50,7 @@ class Connection extends AbstractConnection
     /**
      * Set driver
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver(Pdo $driver)
     {
@@ -135,7 +135,7 @@ class Connection extends AbstractConnection
     /**
      * Set resource
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setResource(\PDO $resource)
     {

--- a/src/Adapter/Driver/Pdo/Pdo.php
+++ b/src/Adapter/Driver/Pdo/Pdo.php
@@ -66,7 +66,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -91,7 +91,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     /**
      * Register connection
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -122,7 +122,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
      *
      * @param string $name
      * @param AbstractFeature $feature
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addFeature($name, $feature)
     {
@@ -137,7 +137,7 @@ class Pdo implements DriverInterface, DriverFeatureInterface, Profiler\ProfilerA
     /**
      * Setup the default features for Pdo
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setupDefaultFeatures()
     {

--- a/src/Adapter/Driver/Pdo/Result.php
+++ b/src/Adapter/Driver/Pdo/Result.php
@@ -88,7 +88,7 @@ class Result implements Iterator, ResultInterface
      *
      * @param  mixed        $generatedValue
      * @param  int          $rowCount
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function initialize(PDOStatement $resource, $generatedValue, $rowCount = null)
     {

--- a/src/Adapter/Driver/Pdo/Statement.php
+++ b/src/Adapter/Driver/Pdo/Statement.php
@@ -46,7 +46,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Set driver
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver(Pdo $driver)
     {
@@ -55,7 +55,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -74,7 +74,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Initialize
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function initialize(\PDO $connectionResource)
     {
@@ -85,7 +85,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Set resource
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setResource(PDOStatement $pdoStatement)
     {
@@ -107,7 +107,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param string $sql
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -126,7 +126,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {

--- a/src/Adapter/Driver/Pgsql/Connection.php
+++ b/src/Adapter/Driver/Pgsql/Connection.php
@@ -55,7 +55,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param resource $resource
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setResource($resource)
     {
@@ -67,7 +67,7 @@ class Connection extends AbstractConnection
     /**
      * Set driver
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver(Pgsql $driver)
     {
@@ -78,7 +78,7 @@ class Connection extends AbstractConnection
 
     /**
      * @param int|null $type
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setType($type)
     {

--- a/src/Adapter/Driver/Pgsql/Pgsql.php
+++ b/src/Adapter/Driver/Pgsql/Pgsql.php
@@ -50,7 +50,7 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -75,7 +75,7 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Register connection
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -87,7 +87,7 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Register statement prototype
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statement)
     {
@@ -99,7 +99,7 @@ class Pgsql implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Register result prototype
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerResultPrototype(Result $result)
     {

--- a/src/Adapter/Driver/Pgsql/Statement.php
+++ b/src/Adapter/Driver/Pgsql/Statement.php
@@ -44,7 +44,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     protected $parameterContainer;
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver(Pgsql $driver)
     {
@@ -53,7 +53,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -109,7 +109,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * Set sql
      *
      * @param string $sql
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -130,7 +130,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Set parameter container
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {

--- a/src/Adapter/Driver/Sqlsrv/Connection.php
+++ b/src/Adapter/Driver/Sqlsrv/Connection.php
@@ -46,7 +46,7 @@ class Connection extends AbstractConnection
     /**
      * Set driver
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver(Sqlsrv $driver)
     {
@@ -74,7 +74,7 @@ class Connection extends AbstractConnection
      * Set resource
      *
      * @param  resource $resource
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setResource($resource)

--- a/src/Adapter/Driver/Sqlsrv/Result.php
+++ b/src/Adapter/Driver/Sqlsrv/Result.php
@@ -39,7 +39,7 @@ class Result implements Iterator, ResultInterface
      *
      * @param  resource $resource
      * @param  mixed    $generatedValue
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function initialize($resource, $generatedValue = null)
     {

--- a/src/Adapter/Driver/Sqlsrv/Sqlsrv.php
+++ b/src/Adapter/Driver/Sqlsrv/Sqlsrv.php
@@ -39,7 +39,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -64,7 +64,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Register connection
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerConnection(Connection $connection)
     {
@@ -76,7 +76,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Register statement prototype
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerStatementPrototype(Statement $statementPrototype)
     {
@@ -88,7 +88,7 @@ class Sqlsrv implements DriverInterface, Profiler\ProfilerAwareInterface
     /**
      * Register result prototype
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function registerResultPrototype(Result $resultPrototype)
     {

--- a/src/Adapter/Driver/Sqlsrv/Statement.php
+++ b/src/Adapter/Driver/Sqlsrv/Statement.php
@@ -57,7 +57,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Set driver
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDriver(Sqlsrv $driver)
     {
@@ -66,7 +66,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setProfiler(Profiler\ProfilerInterface $profiler)
     {
@@ -89,7 +89,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
      * (there will need to already be a bound param set if it applies to this query)
      *
      * @param resource $resource
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function initialize($resource)
@@ -111,7 +111,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * Set parameter container
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {
@@ -129,7 +129,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param resource $resource
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setResource($resource)
     {
@@ -149,7 +149,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
 
     /**
      * @param string $sql
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -170,7 +170,7 @@ class Statement implements StatementInterface, Profiler\ProfilerAwareInterface
     /**
      * @param string $sql
      * @param array $options
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\RuntimeException
      */
     public function prepare($sql = null, array $options = [])

--- a/src/Adapter/ParameterContainer.php
+++ b/src/Adapter/ParameterContainer.php
@@ -179,7 +179,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      * Offset unset
      *
      * @param  string $name
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     #[ReturnTypeWillChange]
     public function offsetUnset($name)
@@ -195,7 +195,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
      * Set from array
      *
      * @param  array $data
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setFromArray(array $data)
     {
@@ -437,7 +437,7 @@ class ParameterContainer implements Iterator, ArrayAccess, Countable
 
     /**
      * @param array|ParameterContainer $parameters
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function merge($parameters)

--- a/src/Adapter/Platform/Mysql.php
+++ b/src/Adapter/Platform/Mysql.php
@@ -45,7 +45,7 @@ class Mysql extends AbstractPlatform
 
     /**
      * @param \Laminas\Db\Adapter\Driver\Mysqli\Mysqli|\Laminas\Db\Adapter\Driver\Pdo\Pdo|\mysqli|\PDO $driver
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws InvalidArgumentException
      */
     public function setDriver($driver)

--- a/src/Adapter/Platform/Oracle.php
+++ b/src/Adapter/Platform/Oracle.php
@@ -39,7 +39,7 @@ class Oracle extends AbstractPlatform
 
     /**
      * @param Pdo|Oci8 $driver
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws InvalidArgumentException
      */
     public function setDriver($driver)

--- a/src/Adapter/Platform/Postgresql.php
+++ b/src/Adapter/Platform/Postgresql.php
@@ -45,7 +45,7 @@ class Postgresql extends AbstractPlatform
 
     /**
      * @param Pgsql\Pgsql|Pdo\Pdo|resource|\PDO $driver
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setDriver($driver)

--- a/src/Adapter/Platform/SqlServer.php
+++ b/src/Adapter/Platform/SqlServer.php
@@ -41,7 +41,7 @@ class SqlServer extends AbstractPlatform
 
     /**
      * @param Sqlsrv|\Laminas\Db\Adapter\Driver\Pdo\Pdo|resource|\PDO $driver
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws InvalidArgumentException
      */
     public function setDriver($driver)

--- a/src/Adapter/Platform/Sqlite.php
+++ b/src/Adapter/Platform/Sqlite.php
@@ -29,7 +29,7 @@ class Sqlite extends AbstractPlatform
 
     /**
      * @param Pdo\Pdo|\PDO $driver
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setDriver($driver)

--- a/src/Adapter/Profiler/Profiler.php
+++ b/src/Adapter/Profiler/Profiler.php
@@ -20,7 +20,7 @@ class Profiler implements ProfilerInterface
 
     /**
      * @param string|StatementContainerInterface $target
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws InvalidArgumentException
      */
     public function profilerStart($target)
@@ -49,7 +49,7 @@ class Profiler implements ProfilerInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function profilerFinish()
     {

--- a/src/Adapter/StatementContainer.php
+++ b/src/Adapter/StatementContainer.php
@@ -23,7 +23,7 @@ class StatementContainer implements StatementContainerInterface
 
     /**
      * @param string $sql
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSql($sql)
     {
@@ -40,7 +40,7 @@ class StatementContainer implements StatementContainerInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setParameterContainer(ParameterContainer $parameterContainer)
     {

--- a/src/Metadata/Object/ColumnObject.php
+++ b/src/Metadata/Object/ColumnObject.php
@@ -93,7 +93,7 @@ class ColumnObject
      * Set table name
      *
      * @param string $tableName
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setTableName($tableName)
     {
@@ -131,7 +131,7 @@ class ColumnObject
 
     /**
      * @param int $ordinalPosition to set
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setOrdinalPosition($ordinalPosition)
     {
@@ -149,7 +149,7 @@ class ColumnObject
 
     /**
      * @param mixed $columnDefault to set
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setColumnDefault($columnDefault)
     {
@@ -167,7 +167,7 @@ class ColumnObject
 
     /**
      * @param bool $isNullable to set
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setIsNullable($isNullable)
     {
@@ -193,7 +193,7 @@ class ColumnObject
 
     /**
      * @param string $dataType the $dataType to set
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDataType($dataType)
     {
@@ -211,7 +211,7 @@ class ColumnObject
 
     /**
      * @param int $characterMaximumLength the $characterMaximumLength to set
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setCharacterMaximumLength($characterMaximumLength)
     {
@@ -229,7 +229,7 @@ class ColumnObject
 
     /**
      * @param int $characterOctetLength the $characterOctetLength to set
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setCharacterOctetLength($characterOctetLength)
     {
@@ -247,7 +247,7 @@ class ColumnObject
 
     /**
      * @param int $numericPrecision the $numericPrevision to set
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setNumericPrecision($numericPrecision)
     {
@@ -265,7 +265,7 @@ class ColumnObject
 
     /**
      * @param int $numericScale the $numericScale to set
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setNumericScale($numericScale)
     {
@@ -283,7 +283,7 @@ class ColumnObject
 
     /**
      * @param  bool $numericUnsigned
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setNumericUnsigned($numericUnsigned)
     {
@@ -309,7 +309,7 @@ class ColumnObject
 
     /**
      * @param array $erratas
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setErratas(array $erratas)
     {
@@ -335,7 +335,7 @@ class ColumnObject
     /**
      * @param string $errataName
      * @param mixed $errataValue
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setErrata($errataName, $errataValue)
     {

--- a/src/Metadata/Object/ConstraintKeyObject.php
+++ b/src/Metadata/Object/ConstraintKeyObject.php
@@ -58,7 +58,7 @@ class ConstraintKeyObject
      * Set column name
      *
      * @param  string $columnName
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setColumnName($columnName)
     {
@@ -80,7 +80,7 @@ class ConstraintKeyObject
      * Set ordinal position
      *
      * @param  int $ordinalPosition
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setOrdinalPosition($ordinalPosition)
     {
@@ -102,7 +102,7 @@ class ConstraintKeyObject
      * Set position in unique constraint
      *
      * @param  bool $positionInUniqueConstraint
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setPositionInUniqueConstraint($positionInUniqueConstraint)
     {
@@ -124,7 +124,7 @@ class ConstraintKeyObject
      * Set referenced table schema
      *
      * @param string $referencedTableSchema
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setReferencedTableSchema($referencedTableSchema)
     {
@@ -146,7 +146,7 @@ class ConstraintKeyObject
      * Set Referenced table name
      *
      * @param  string $referencedTableName
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setReferencedTableName($referencedTableName)
     {
@@ -168,7 +168,7 @@ class ConstraintKeyObject
      * Set referenced column name
      *
      * @param  string $referencedColumnName
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setReferencedColumnName($referencedColumnName)
     {

--- a/src/Metadata/Object/ConstraintObject.php
+++ b/src/Metadata/Object/ConstraintObject.php
@@ -112,7 +112,7 @@ class ConstraintObject
      * Set table name
      *
      * @param  string $tableName
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setTableName($tableName)
     {
@@ -160,7 +160,7 @@ class ConstraintObject
      * Set Columns.
      *
      * @param string[] $columns
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setColumns(array $columns)
     {
@@ -182,7 +182,7 @@ class ConstraintObject
      * Set Referenced Table Schema.
      *
      * @param string $referencedTableSchema
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setReferencedTableSchema($referencedTableSchema)
     {
@@ -204,7 +204,7 @@ class ConstraintObject
      * Set Referenced Table Name.
      *
      * @param string $referencedTableName
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setReferencedTableName($referencedTableName)
     {
@@ -226,7 +226,7 @@ class ConstraintObject
      * Set Referenced Columns.
      *
      * @param string[] $referencedColumns
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setReferencedColumns(array $referencedColumns)
     {
@@ -248,7 +248,7 @@ class ConstraintObject
      * Set Match Option.
      *
      * @param string $matchOption
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setMatchOption($matchOption)
     {
@@ -270,7 +270,7 @@ class ConstraintObject
      * Set Update Rule.
      *
      * @param string $updateRule
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setUpdateRule($updateRule)
     {
@@ -292,7 +292,7 @@ class ConstraintObject
      * Set Delete Rule.
      *
      * @param string $deleteRule
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDeleteRule($deleteRule)
     {
@@ -314,7 +314,7 @@ class ConstraintObject
      * Set Check Clause.
      *
      * @param string $checkClause
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setCheckClause($checkClause)
     {

--- a/src/Metadata/Object/TriggerObject.php
+++ b/src/Metadata/Object/TriggerObject.php
@@ -65,7 +65,7 @@ class TriggerObject
      * Set Name.
      *
      * @param string $name
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setName($name)
     {
@@ -87,7 +87,7 @@ class TriggerObject
      * Set Event Manipulation.
      *
      * @param string $eventManipulation
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setEventManipulation($eventManipulation)
     {
@@ -109,7 +109,7 @@ class TriggerObject
      * Set Event Object Catalog.
      *
      * @param string $eventObjectCatalog
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setEventObjectCatalog($eventObjectCatalog)
     {
@@ -131,7 +131,7 @@ class TriggerObject
      * Set Event Object Schema.
      *
      * @param string $eventObjectSchema
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setEventObjectSchema($eventObjectSchema)
     {
@@ -153,7 +153,7 @@ class TriggerObject
      * Set Event Object Table.
      *
      * @param string $eventObjectTable
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setEventObjectTable($eventObjectTable)
     {
@@ -175,7 +175,7 @@ class TriggerObject
      * Set Action Order.
      *
      * @param string $actionOrder
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setActionOrder($actionOrder)
     {
@@ -197,7 +197,7 @@ class TriggerObject
      * Set Action Condition.
      *
      * @param string $actionCondition
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setActionCondition($actionCondition)
     {
@@ -219,7 +219,7 @@ class TriggerObject
      * Set Action Statement.
      *
      * @param string $actionStatement
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setActionStatement($actionStatement)
     {
@@ -241,7 +241,7 @@ class TriggerObject
      * Set Action Orientation.
      *
      * @param string $actionOrientation
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setActionOrientation($actionOrientation)
     {
@@ -263,7 +263,7 @@ class TriggerObject
      * Set Action Timing.
      *
      * @param string $actionTiming
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setActionTiming($actionTiming)
     {
@@ -285,7 +285,7 @@ class TriggerObject
      * Set Action Reference Old Table.
      *
      * @param string $actionReferenceOldTable
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setActionReferenceOldTable($actionReferenceOldTable)
     {
@@ -307,7 +307,7 @@ class TriggerObject
      * Set Action Reference New Table.
      *
      * @param string $actionReferenceNewTable
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setActionReferenceNewTable($actionReferenceNewTable)
     {
@@ -329,7 +329,7 @@ class TriggerObject
      * Set Action Reference Old Row.
      *
      * @param string $actionReferenceOldRow
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setActionReferenceOldRow($actionReferenceOldRow)
     {
@@ -351,7 +351,7 @@ class TriggerObject
      * Set Action Reference New Row.
      *
      * @param string $actionReferenceNewRow
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setActionReferenceNewRow($actionReferenceNewRow)
     {
@@ -373,7 +373,7 @@ class TriggerObject
      * Set Created.
      *
      * @param DateTime $created
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setCreated($created)
     {

--- a/src/Metadata/Object/ViewObject.php
+++ b/src/Metadata/Object/ViewObject.php
@@ -23,7 +23,7 @@ class ViewObject extends AbstractTableObject
 
     /**
      * @param string $viewDefinition to set
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setViewDefinition($viewDefinition)
     {
@@ -41,7 +41,7 @@ class ViewObject extends AbstractTableObject
 
     /**
      * @param string $checkOption to set
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setCheckOption($checkOption)
     {
@@ -59,7 +59,7 @@ class ViewObject extends AbstractTableObject
 
     /**
      * @param bool $isUpdatable to set
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setIsUpdatable($isUpdatable)
     {

--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -48,7 +48,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
      * Set the data source for the result set
      *
      * @param  array|Iterator|IteratorAggregate|ResultInterface $dataSource
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function initialize($dataSource)
@@ -91,7 +91,7 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\RuntimeException
      */
     public function buffer()

--- a/src/ResultSet/HydratingResultSet.php
+++ b/src/ResultSet/HydratingResultSet.php
@@ -38,7 +38,7 @@ class HydratingResultSet extends AbstractResultSet
      * Set the row object prototype
      *
      * @param  object $objectPrototype
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setObjectPrototype($objectPrototype)
@@ -65,7 +65,7 @@ class HydratingResultSet extends AbstractResultSet
     /**
      * Set the hydrator to use for each row object
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setHydrator(HydratorInterface $hydrator)
     {

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -56,7 +56,7 @@ class ResultSet extends AbstractResultSet
      * Set the row object prototype
      *
      * @param  ArrayObject $arrayObjectPrototype
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setArrayObjectPrototype($arrayObjectPrototype)

--- a/src/RowGateway/AbstractRowGateway.php
+++ b/src/RowGateway/AbstractRowGateway.php
@@ -76,7 +76,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
      *
      * @param  array $rowData
      * @param  bool  $rowExistsInDatabase
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function populate(array $rowData, $rowExistsInDatabase = false)
     {
@@ -238,7 +238,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
      *
      * @param  string $offset
      * @param  mixed $value
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
@@ -251,7 +251,7 @@ abstract class AbstractRowGateway implements ArrayAccess, Countable, RowGatewayI
      * Offset unset
      *
      * @param  string $offset
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     #[ReturnTypeWillChange]
     public function offsetUnset($offset)

--- a/src/RowGateway/Feature/FeatureSet.php
+++ b/src/RowGateway/Feature/FeatureSet.php
@@ -31,7 +31,7 @@ class FeatureSet
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setRowGateway(AbstractRowGateway $rowGateway)
     {
@@ -60,7 +60,7 @@ class FeatureSet
 
     /**
      * @param array $features
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addFeatures(array $features)
     {
@@ -71,7 +71,7 @@ class FeatureSet
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addFeature(AbstractFeature $feature)
     {

--- a/src/Sql/Combine.php
+++ b/src/Sql/Combine.php
@@ -53,7 +53,7 @@ class Combine extends AbstractPreparableSql
      * @param Select|array $select
      * @param string $type
      * @param string $modifier
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function combine($select, $type = self::COMBINE_UNION, $modifier = '')
@@ -93,7 +93,7 @@ class Combine extends AbstractPreparableSql
      *
      * @param Select|array $select
      * @param string       $modifier
-     * @return self
+     * @return $this
      */
     public function union($select, $modifier = '')
     {
@@ -105,7 +105,7 @@ class Combine extends AbstractPreparableSql
      *
      * @param Select|array $select
      * @param string       $modifier
-     * @return self
+     * @return $this
      */
     public function except($select, $modifier = '')
     {
@@ -117,7 +117,7 @@ class Combine extends AbstractPreparableSql
      *
      * @param Select|array $select
      * @param string $modifier
-     * @return self
+     * @return $this
      */
     public function intersect($select, $modifier = '')
     {
@@ -154,7 +154,7 @@ class Combine extends AbstractPreparableSql
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function alignColumns()
     {

--- a/src/Sql/Ddl/AlterTable.php
+++ b/src/Sql/Ddl/AlterTable.php
@@ -79,7 +79,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setTable($name)
     {
@@ -89,7 +89,7 @@ class AlterTable extends AbstractSql implements SqlInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addColumn(Column\ColumnInterface $column)
     {
@@ -100,7 +100,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function changeColumn($name, Column\ColumnInterface $column)
     {
@@ -111,7 +111,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function dropColumn($name)
     {
@@ -122,7 +122,7 @@ class AlterTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function dropConstraint($name)
     {
@@ -132,7 +132,7 @@ class AlterTable extends AbstractSql implements SqlInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addConstraint(Constraint\ConstraintInterface $constraint)
     {

--- a/src/Sql/Ddl/Column/AbstractLengthColumn.php
+++ b/src/Sql/Ddl/Column/AbstractLengthColumn.php
@@ -21,7 +21,7 @@ abstract class AbstractLengthColumn extends Column
 
     /**
      * @param  int $length
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setLength($length)
     {

--- a/src/Sql/Ddl/Column/AbstractPrecisionColumn.php
+++ b/src/Sql/Ddl/Column/AbstractPrecisionColumn.php
@@ -28,7 +28,7 @@ abstract class AbstractPrecisionColumn extends AbstractLengthColumn
 
     /**
      * @param  int $digits
-     * @return self
+     * @return $this
      */
     public function setDigits($digits)
     {
@@ -45,7 +45,7 @@ abstract class AbstractPrecisionColumn extends AbstractLengthColumn
 
     /**
      * @param int|null $decimal
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDecimal($decimal)
     {

--- a/src/Sql/Ddl/Column/Column.php
+++ b/src/Sql/Ddl/Column/Column.php
@@ -45,7 +45,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  string $name
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setName($name)
     {
@@ -63,7 +63,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  bool $nullable
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setNullable($nullable)
     {
@@ -81,7 +81,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  null|string|int $default
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setDefault($default)
     {
@@ -99,7 +99,7 @@ class Column implements ColumnInterface
 
     /**
      * @param  array $options
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setOptions(array $options)
     {
@@ -110,7 +110,7 @@ class Column implements ColumnInterface
     /**
      * @param  string $name
      * @param  string $value
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setOption($name, $value)
     {
@@ -127,7 +127,7 @@ class Column implements ColumnInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addConstraint(ConstraintInterface $constraint)
     {

--- a/src/Sql/Ddl/Constraint/AbstractConstraint.php
+++ b/src/Sql/Ddl/Constraint/AbstractConstraint.php
@@ -40,7 +40,7 @@ abstract class AbstractConstraint implements ConstraintInterface
 
     /**
      * @param  string $name
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setName($name)
     {
@@ -58,7 +58,7 @@ abstract class AbstractConstraint implements ConstraintInterface
 
     /**
      * @param  null|string|array $columns
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setColumns($columns)
     {
@@ -69,7 +69,7 @@ abstract class AbstractConstraint implements ConstraintInterface
 
     /**
      * @param  string $column
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addColumn($column)
     {

--- a/src/Sql/Ddl/Constraint/ForeignKey.php
+++ b/src/Sql/Ddl/Constraint/ForeignKey.php
@@ -65,7 +65,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  string $referenceTable
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setReferenceTable($referenceTable)
     {
@@ -83,7 +83,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  null|string|array $referenceColumn
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setReferenceColumn($referenceColumn)
     {
@@ -102,7 +102,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  string $onDeleteRule
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setOnDeleteRule($onDeleteRule)
     {
@@ -121,7 +121,7 @@ class ForeignKey extends AbstractConstraint
 
     /**
      * @param  string $onUpdateRule
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setOnUpdateRule($onUpdateRule)
     {

--- a/src/Sql/Ddl/CreateTable.php
+++ b/src/Sql/Ddl/CreateTable.php
@@ -57,7 +57,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  bool $temporary
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setTemporary($temporary)
     {
@@ -75,7 +75,7 @@ class CreateTable extends AbstractSql implements SqlInterface
 
     /**
      * @param  string $name
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setTable($name)
     {
@@ -84,7 +84,7 @@ class CreateTable extends AbstractSql implements SqlInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addColumn(Column\ColumnInterface $column)
     {
@@ -93,7 +93,7 @@ class CreateTable extends AbstractSql implements SqlInterface
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addConstraint(Constraint\ConstraintInterface $constraint)
     {

--- a/src/Sql/Delete.php
+++ b/src/Sql/Delete.php
@@ -60,7 +60,7 @@ class Delete extends AbstractPreparableSql
      * Create from statement
      *
      * @param  string|TableIdentifier $table
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function from($table)
     {
@@ -88,7 +88,7 @@ class Delete extends AbstractPreparableSql
      *
      * @param Where|Closure|string|array $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {

--- a/src/Sql/Expression.php
+++ b/src/Sql/Expression.php
@@ -59,7 +59,7 @@ class Expression extends AbstractExpression
 
     /**
      * @param string $expression
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setExpression($expression)
@@ -81,7 +81,7 @@ class Expression extends AbstractExpression
 
     /**
      * @param scalar|array $parameters
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setParameters($parameters)
@@ -105,7 +105,7 @@ class Expression extends AbstractExpression
      * @deprecated
      *
      * @param array $types
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setTypes(array $types)
     {

--- a/src/Sql/Insert.php
+++ b/src/Sql/Insert.php
@@ -64,7 +64,7 @@ class Insert extends AbstractPreparableSql
      * Create INTO clause
      *
      * @param  string|TableIdentifier $table
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function into($table)
     {
@@ -76,7 +76,7 @@ class Insert extends AbstractPreparableSql
      * Specify columns
      *
      * @param  array $columns
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function columns(array $columns)
     {
@@ -89,7 +89,7 @@ class Insert extends AbstractPreparableSql
      *
      * @param  array|Select $values
      * @param  string $flag one of VALUES_MERGE or VALUES_SET; defaults to VALUES_SET
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function values($values, $flag = self::VALUES_SET)
@@ -145,7 +145,7 @@ class Insert extends AbstractPreparableSql
     /**
      * Create INTO SELECT clause
      *
-     * @return self
+     * @return $this
      */
     public function select(Select $select)
     {
@@ -239,7 +239,7 @@ class Insert extends AbstractPreparableSql
      *
      * @param  string $name
      * @param  mixed $value
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function __set($name, $value)
     {

--- a/src/Sql/Join.php
+++ b/src/Sql/Join.php
@@ -125,7 +125,7 @@ class Join implements Iterator, Countable
      *     of column names, or (a) specification(s) such as SQL_STAR representing
      *     the columns to join.
      * @param string $type The JOIN type to use; see the JOIN_* constants.
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException For invalid $name values.
      */
     public function join($name, $on, $columns = [Select::SQL_STAR], $type = self::JOIN_INNER)
@@ -153,7 +153,7 @@ class Join implements Iterator, Countable
     /**
      * Reset to an empty list of JOIN specifications.
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function reset()
     {

--- a/src/Sql/Literal.php
+++ b/src/Sql/Literal.php
@@ -19,7 +19,7 @@ class Literal implements ExpressionInterface
 
     /**
      * @param string $literal
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setLiteral($literal)
     {

--- a/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
+++ b/src/Sql/Platform/Mysql/Ddl/AlterTableDecorator.php
@@ -37,7 +37,7 @@ class AlterTableDecorator extends AlterTable implements PlatformDecoratorInterfa
 
     /**
      * @param AlterTable $subject
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/src/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
+++ b/src/Sql/Platform/Mysql/Ddl/CreateTableDecorator.php
@@ -36,7 +36,7 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
 
     /**
      * @param CreateTable $subject
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/src/Sql/Platform/PlatformDecoratorInterface.php
+++ b/src/Sql/Platform/PlatformDecoratorInterface.php
@@ -6,7 +6,7 @@ interface PlatformDecoratorInterface
 {
     /**
      * @param null|object $subject
-     * @return self
+     * @return $this
      */
     public function setSubject($subject);
 }

--- a/src/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
+++ b/src/Sql/Platform/SqlServer/Ddl/CreateTableDecorator.php
@@ -15,7 +15,7 @@ class CreateTableDecorator extends CreateTable implements PlatformDecoratorInter
 
     /**
      * @param CreateTable $subject
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/src/Sql/Platform/Sqlite/SelectDecorator.php
+++ b/src/Sql/Platform/Sqlite/SelectDecorator.php
@@ -17,7 +17,7 @@ class SelectDecorator extends Select implements PlatformDecoratorInterface
      * Set Subject
      *
      * @param Select $select
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSubject($select)
     {

--- a/src/Sql/Predicate/Between.php
+++ b/src/Sql/Predicate/Between.php
@@ -42,7 +42,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set identifier for comparison
      *
      * @param  string $identifier
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -64,7 +64,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set minimum boundary for comparison
      *
      * @param  int|float|string $minValue
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setMinValue($minValue)
     {
@@ -86,7 +86,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set maximum boundary for comparison
      *
      * @param  int|float|string $maxValue
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setMaxValue($maxValue)
     {
@@ -108,7 +108,7 @@ class Between extends AbstractExpression implements PredicateInterface
      * Set specification string to use in forming SQL predicate
      *
      * @param  string $specification
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSpecification($specification)
     {

--- a/src/Sql/Predicate/In.php
+++ b/src/Sql/Predicate/In.php
@@ -47,7 +47,7 @@ class In extends AbstractExpression implements PredicateInterface
      * Set identifier for comparison
      *
      * @param  string|array $identifier
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -70,7 +70,7 @@ class In extends AbstractExpression implements PredicateInterface
      * Set set of values for IN comparison
      *
      * @param  array|Select                       $valueSet
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setValueSet($valueSet)

--- a/src/Sql/Predicate/IsNull.php
+++ b/src/Sql/Predicate/IsNull.php
@@ -28,7 +28,7 @@ class IsNull extends AbstractExpression implements PredicateInterface
      * Set identifier for comparison
      *
      * @param  string $identifier
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -50,7 +50,7 @@ class IsNull extends AbstractExpression implements PredicateInterface
      * Set specification string to use in forming SQL predicate
      *
      * @param  string $specification
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSpecification($specification)
     {

--- a/src/Sql/Predicate/Like.php
+++ b/src/Sql/Predicate/Like.php
@@ -31,7 +31,7 @@ class Like extends AbstractExpression implements PredicateInterface
 
     /**
      * @param  string $identifier
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setIdentifier($identifier)
     {
@@ -49,7 +49,7 @@ class Like extends AbstractExpression implements PredicateInterface
 
     /**
      * @param  string $like
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setLike($like)
     {
@@ -67,7 +67,7 @@ class Like extends AbstractExpression implements PredicateInterface
 
     /**
      * @param  string $specification
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSpecification($specification)
     {

--- a/src/Sql/Predicate/Operator.php
+++ b/src/Sql/Predicate/Operator.php
@@ -93,7 +93,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      * Set left side of operator
      *
      * @param  int|float|bool|string $left
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setLeft($left)
     {
@@ -121,7 +121,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      * Set parameter type for left side of operator
      *
      * @param  string $type TYPE_IDENTIFIER or TYPE_VALUE {@see allowedTypes}
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setLeftType($type)
@@ -154,7 +154,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      * Set operator string
      *
      * @param  string $operator
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setOperator($operator)
     {
@@ -177,7 +177,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      * Set right side of operator
      *
      * @param  int|float|bool|string $right
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setRight($right)
     {
@@ -205,7 +205,7 @@ class Operator extends AbstractExpression implements PredicateInterface
      * Set parameter type for right side of operator
      *
      * @param  string $type TYPE_IDENTIFIER or TYPE_VALUE {@see allowedTypes}
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setRightType($type)

--- a/src/Sql/Predicate/Predicate.php
+++ b/src/Sql/Predicate/Predicate.php
@@ -74,7 +74,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string|Expression $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function equalTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -96,7 +96,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string|Expression $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function notEqualTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -118,7 +118,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string|Expression $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function lessThan($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -140,7 +140,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string|Expression $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function greaterThan($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -162,7 +162,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string|Expression $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function lessThanOrEqualTo($left, $right, $leftType = self::TYPE_IDENTIFIER, $rightType = self::TYPE_VALUE)
     {
@@ -184,7 +184,7 @@ class Predicate extends PredicateSet
      * @param  int|float|bool|string|Expression $right
      * @param  string $leftType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_IDENTIFIER {@see allowedTypes}
      * @param  string $rightType TYPE_IDENTIFIER or TYPE_VALUE by default TYPE_VALUE {@see allowedTypes}
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function greaterThanOrEqualTo(
         $left,
@@ -208,7 +208,7 @@ class Predicate extends PredicateSet
      *
      * @param  string|Expression $identifier
      * @param  string $like
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function like($identifier, $like)
     {
@@ -228,7 +228,7 @@ class Predicate extends PredicateSet
      *
      * @param  string|Expression $identifier
      * @param  string $notLike
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function notLike($identifier, $notLike)
     {
@@ -245,7 +245,7 @@ class Predicate extends PredicateSet
      *
      * @param string $expression
      * @param null|array $parameters
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function expression($expression, $parameters = null)
     {
@@ -264,7 +264,7 @@ class Predicate extends PredicateSet
      * Literal predicate, for parameters, use expression()
      *
      * @param  string $literal
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function literal($literal)
     {
@@ -294,7 +294,7 @@ class Predicate extends PredicateSet
      * Utilizes IsNull predicate
      *
      * @param  string|Expression $identifier
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function isNull($identifier)
     {
@@ -313,7 +313,7 @@ class Predicate extends PredicateSet
      * Utilizes IsNotNull predicate
      *
      * @param  string|Expression $identifier
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function isNotNull($identifier)
     {
@@ -333,7 +333,7 @@ class Predicate extends PredicateSet
      *
      * @param  string|Expression $identifier
      * @param array|Select $valueSet
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function in($identifier, $valueSet = null)
     {
@@ -353,7 +353,7 @@ class Predicate extends PredicateSet
      *
      * @param  string|Expression $identifier
      * @param array|Select $valueSet
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function notIn($identifier, $valueSet = null)
     {
@@ -374,7 +374,7 @@ class Predicate extends PredicateSet
      * @param  string|Expression $identifier
      * @param  int|float|string $minValue
      * @param  int|float|string $maxValue
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function between($identifier, $minValue, $maxValue)
     {
@@ -395,7 +395,7 @@ class Predicate extends PredicateSet
      * @param  string|Expression $identifier
      * @param  int|float|string $minValue
      * @param  int|float|string $maxValue
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function notBetween($identifier, $minValue, $maxValue)
     {
@@ -415,7 +415,7 @@ class Predicate extends PredicateSet
      * AND / OR combination operator, thus allowing generic predicates to be
      * used fluently within where chains as any other concrete predicate.
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     // phpcs:ignore Generic.NamingConventions.ConstructorName.OldStyle
     public function predicate(PredicateInterface $predicate)
@@ -435,7 +435,7 @@ class Predicate extends PredicateSet
      * Overloads "or", "and", "nest", and "unnest"
      *
      * @param  string $name
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function __get($name)
     {

--- a/src/Sql/Predicate/PredicateSet.php
+++ b/src/Sql/Predicate/PredicateSet.php
@@ -50,7 +50,7 @@ class PredicateSet implements PredicateInterface, Countable
      * Add predicate to set
      *
      * @param  string $combination
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addPredicate(PredicateInterface $predicate, $combination = null)
     {
@@ -72,7 +72,7 @@ class PredicateSet implements PredicateInterface, Countable
      *
      * @param PredicateInterface|Closure|string|array $predicates
      * @param string $combination
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function addPredicates($predicates, $combination = self::OP_AND)
@@ -145,7 +145,7 @@ class PredicateSet implements PredicateInterface, Countable
     /**
      * Add predicate using OR operator
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function orPredicate(PredicateInterface $predicate)
     {
@@ -156,7 +156,7 @@ class PredicateSet implements PredicateInterface, Countable
     /**
      * Add predicate using AND operator
      *
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function andPredicate(PredicateInterface $predicate)
     {

--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -180,7 +180,7 @@ class Select extends AbstractPreparableSql
      * Create from clause
      *
      * @param  string|array|TableIdentifier $table
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function from($table)
@@ -209,7 +209,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param string|Expression $quantifier DISTINCT|ALL
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function quantifier($quantifier)
@@ -240,7 +240,7 @@ class Select extends AbstractPreparableSql
      *
      * @param  array $columns
      * @param  bool  $prefixColumnsWithTable
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function columns(array $columns, $prefixColumnsWithTable = true)
     {
@@ -256,7 +256,7 @@ class Select extends AbstractPreparableSql
      * @param  string|Predicate\Expression $on
      * @param  string|array $columns
      * @param  string $type one of the JOIN_* constants
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function join($name, $on, $columns = self::SQL_STAR, $type = self::JOIN_INNER)
@@ -271,7 +271,7 @@ class Select extends AbstractPreparableSql
      *
      * @param Where|Closure|string|array|Predicate\PredicateInterface $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
@@ -286,7 +286,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param mixed $group
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function group($group)
     {
@@ -305,7 +305,7 @@ class Select extends AbstractPreparableSql
      *
      * @param Where|Closure|string|array $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function having($predicate, $combination = Predicate\PredicateSet::OP_AND)
     {
@@ -319,7 +319,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param string|array|Expression $order
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function order($order)
     {
@@ -344,7 +344,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param int $limit
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function limit($limit)
@@ -363,7 +363,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param int $offset
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function offset($offset)
@@ -383,7 +383,7 @@ class Select extends AbstractPreparableSql
     /**
      * @param string $type
      * @param string $modifier
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function combine(Select $select, $type = self::COMBINE_UNION, $modifier = '')
@@ -403,7 +403,7 @@ class Select extends AbstractPreparableSql
 
     /**
      * @param string $part
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function reset($part)
@@ -454,7 +454,7 @@ class Select extends AbstractPreparableSql
     /**
      * @param string $index
      * @param string|array<string, array> $specification
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSpecification($index, $specification)
     {

--- a/src/Sql/Sql.php
+++ b/src/Sql/Sql.php
@@ -53,7 +53,7 @@ class Sql
 
     /**
      * @param string|array|TableIdentifier $table
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function setTable($table)

--- a/src/Sql/Update.php
+++ b/src/Sql/Update.php
@@ -81,7 +81,7 @@ class Update extends AbstractPreparableSql
      * Specify table for statement
      *
      * @param  string|TableIdentifier $table
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function table($table)
     {
@@ -94,7 +94,7 @@ class Update extends AbstractPreparableSql
      *
      * @param  array $values Associative array of key values
      * @param  string $flag One of the VALUES_* constants
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function set(array $values, $flag = self::VALUES_SET)
@@ -117,7 +117,7 @@ class Update extends AbstractPreparableSql
      *
      * @param Where|Closure|string|array $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function where($predicate, $combination = Predicate\PredicateSet::OP_AND)
@@ -136,7 +136,7 @@ class Update extends AbstractPreparableSql
      * @param  string|array $name
      * @param  string $on
      * @param  string $type one of the JOIN_* constants
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      * @throws Exception\InvalidArgumentException
      */
     public function join($name, $on, $type = Join::JOIN_INNER)

--- a/src/TableGateway/Feature/FeatureSet.php
+++ b/src/TableGateway/Feature/FeatureSet.php
@@ -29,7 +29,7 @@ class FeatureSet
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setTableGateway(AbstractTableGateway $tableGateway)
     {
@@ -58,7 +58,7 @@ class FeatureSet
 
     /**
      * @param array $features
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addFeatures(array $features)
     {
@@ -69,7 +69,7 @@ class FeatureSet
     }
 
     /**
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function addFeature(AbstractFeature $feature)
     {

--- a/test/unit/TestAsset/DeleteDecorator.php
+++ b/test/unit/TestAsset/DeleteDecorator.php
@@ -11,7 +11,7 @@ class DeleteDecorator extends Sql\Delete implements Sql\Platform\PlatformDecorat
 
     /**
      * @param null|object $subject
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/test/unit/TestAsset/InsertDecorator.php
+++ b/test/unit/TestAsset/InsertDecorator.php
@@ -11,7 +11,7 @@ class InsertDecorator extends Sql\Insert implements Sql\Platform\PlatformDecorat
 
     /**
      * @param null|object $subject
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/test/unit/TestAsset/SelectDecorator.php
+++ b/test/unit/TestAsset/SelectDecorator.php
@@ -11,7 +11,7 @@ class SelectDecorator extends Sql\Select implements Sql\Platform\PlatformDecorat
 
     /**
      * @param null|object $subject
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSubject($subject)
     {

--- a/test/unit/TestAsset/UpdateDecorator.php
+++ b/test/unit/TestAsset/UpdateDecorator.php
@@ -11,7 +11,7 @@ class UpdateDecorator extends Sql\Update implements Sql\Platform\PlatformDecorat
 
     /**
      * @param null|object $subject
-     * @return self Provides a fluent interface
+     * @return $this Provides a fluent interface
      */
     public function setSubject($subject)
     {


### PR DESCRIPTION
Obvious fix.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes #233: Predicate methods claim to return self (actually: $this or static)