### PR TITLE
feat: Added support for json serialization for AbstractResultSet

### DIFF
--- a/src/ResultSet/AbstractResultSet.php
+++ b/src/ResultSet/AbstractResultSet.php
@@ -6,6 +6,7 @@ use ArrayIterator;
 use Countable;
 use Iterator;
 use IteratorAggregate;
+use JsonSerializable;
 use Laminas\Db\Adapter\Driver\ResultInterface;
 // phpcs:ignore SlevomatCodingStandard.Namespaces.UnusedUses.UnusedUse
 use ReturnTypeWillChange;
@@ -19,7 +20,7 @@ use function key;
 use function method_exists;
 use function reset;
 
-abstract class AbstractResultSet implements Iterator, ResultSetInterface
+abstract class AbstractResultSet implements Iterator, ResultSetInterface, JsonSerializable
 {
     /**
      * if -1, datasource is already buffered
@@ -299,5 +300,10 @@ abstract class AbstractResultSet implements Iterator, ResultSetInterface
             $return[] = method_exists($row, 'toArray') ? $row->toArray() : $row->getArrayCopy();
         }
         return $return;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 }

--- a/test/unit/ResultSet/AbstractResultSetTest.php
+++ b/test/unit/ResultSet/AbstractResultSetTest.php
@@ -236,6 +236,23 @@ class AbstractResultSetTest extends TestCase
     }
 
     /**
+     * @covers \Laminas\Db\ResultSet\AbstractResultSet::jsonSerialize
+     */
+    public function testJsonSerialize()
+    {
+        $resultSet = $this->getMockForAbstractClass(AbstractResultSet::class);
+        $resultSet->initialize(new ArrayIterator([
+            ['id' => 1, 'name' => 'one'],
+            ['id' => 2, 'name' => 'two'],
+            ['id' => 3, 'name' => 'three'],
+        ]));
+        self::assertEquals(
+            $resultSet->toArray(),
+            $resultSet->jsonSerialize()
+        );
+    }
+
+    /**
      * Test multiple iterations with buffer
      *
      * @group issue-6845


### PR DESCRIPTION
Signed-off-by: Julien Guittard <julien.guittard@me.com>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            |  no

### Description

Allow to automatically JSON serialize an AbstractResultSet by calling its `toArray` method
