### PR TITLE
`getSqlStringForSqlObject` method is deprecated - do not use it in documentation

### DIFF
--- a/docs/book/sql-ddl.md
+++ b/docs/book/sql-ddl.md
@@ -139,7 +139,7 @@ use Laminas\Db\Sql\Sql;
 $sql = new Sql($adapter);
 
 $adapter->query(
-    $sql->getSqlStringForSqlObject($ddl),
+    $sql->buildSqlString($ddl),
     $adapter::QUERY_MODE_EXECUTE
 );
 ```


### PR DESCRIPTION
getSqlStringForSqlObject is  deprecated in 2.4. And the method comments suggest using the buildSqlString method instead.

Signed-off-by: Paulo Vitor Bettini de Paiva Lima <paulovitorbal@gmail.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | /no

### Description

Tell us about why this change is necessary:

- Are you adding documentation?
  - TARGET THE default 2.16.x branch

