### PR TITLE
Adds an addtional check for $column being empty.

### DIFF
--- a/src/Sql/AbstractSql.php
+++ b/src/Sql/AbstractSql.php
@@ -396,7 +396,7 @@ abstract class AbstractSql implements SqlInterface
             : $this->processInfo['paramPrefix'] . $namedParameterPrefix;
         $isIdentifier         = false;
         $fromTable            = '';
-        if (is_array($column)) {
+        if (is_array($column) && ! empty($column)) {
             if (isset($column['isIdentifier'])) {
                 $isIdentifier = (bool) $column['isIdentifier'];
             }


### PR DESCRIPTION
When $column is an empty array the rest of the code block is not needed.
Signed-off-by: Joey Smith <jsmith@webinertia.net>

Signed-off-by: Joey Smith <jsmith@webinertia.net>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Line 399, when $column is an empty array the code block should be skipped. Line 406 causes an undefined index error.
