### PR TITLE
Fix: prevent bound parameters being `[null]` when no parameters are given to `Predicate#expression()`

### DIFF
--- a/src/Sql/Predicate/Predicate.php
+++ b/src/Sql/Predicate/Predicate.php
@@ -250,7 +250,7 @@ class Predicate extends PredicateSet
     public function expression($expression, $parameters = null)
     {
         $this->addPredicate(
-            new Expression($expression, $parameters),
+            new Expression($expression, func_num_args() > 1 ? $parameters : []),
             $this->nextPredicateCombineOperator ?: $this->defaultCombination
         );
         $this->nextPredicateCombineOperator = null;


### PR DESCRIPTION
Around `laminas/laminas-db:2.10.1`, a regression was introduced, in which calling `Laminas\Db\Sql\Predicate#expression("an_expression()")` led to crashes like following in downstream consumers:

```
Laminas\Db\Sql\Exception\RuntimeException: The number of replacements in the expression does not match the number of parameters

vendor/laminas/laminas-db/src/Sql/Expression.php:151
vendor/laminas/laminas-db/src/Sql/Predicate/PredicateSet.php:178
vendor/laminas/laminas-db/src/Sql/Predicate/PredicateSet.php:178
vendor/laminas/laminas-db/src/Sql/Predicate/PredicateSet.php:178
vendor/laminas/laminas-db/src/Sql/AbstractSql.php:129
vendor/laminas/laminas-db/src/Sql/Select.php:633
```

This was because predicates were initialized with an `array{null}` by default, when expressions like `$sql->where->expression("some_expression()")` were used.

The usage of `$sql->where->expression("some_expression()", "foo")` remains unchanged with this patch.

This fix targets `2.15.x`, and attempts to make predicates safe to use when no parameters have been given.

While an existing test has indeed been changed, this shouldn't have any effect for downstream consumers, since `Predicate#expression(string)` didn't work (so far) anyway, due to the kind of crash highlighted above.

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no
