### PR TITLE
Fix data loss on multiple `Result#rewind()` calls

### DIFF
--- a/src/Adapter/Driver/Pdo/Result.php
+++ b/src/Adapter/Driver/Pdo/Result.php
@@ -201,9 +201,11 @@ class Result implements Iterator, ResultInterface
                 'This result is a forward only result set, calling rewind() after moving forward is not supported'
             );
         }
-        $this->currentData     = $this->resource->fetch($this->fetchMode);
-        $this->currentComplete = true;
-        $this->position        = 0;
+        if (! $this->currentComplete) {
+            $this->currentData     = $this->resource->fetch($this->fetchMode);
+            $this->currentComplete = true;
+        }
+        $this->position = 0;
     }
 
     /**

--- a/test/unit/Adapter/Driver/Pdo/ResultTest.php
+++ b/test/unit/Adapter/Driver/Pdo/ResultTest.php
@@ -5,9 +5,11 @@ namespace LaminasTest\Db\Adapter\Driver\Pdo;
 use Laminas\Db\Adapter\Driver\Pdo\Result;
 use Laminas\Db\Adapter\Exception\InvalidArgumentException;
 use PDO;
+use PDOStatement;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function assert;
 use function uniqid;
 
 /**
@@ -79,5 +81,36 @@ class ResultTest extends TestCase
         $result->setFetchMode(PDO::FETCH_NAMED);
         self::assertEquals(11, $result->getFetchMode());
         self::assertInstanceOf('stdClass', $result->current());
+    }
+
+    public function testMultipleRewind()
+    {
+        $data     = [
+            ['test' => 1],
+            ['test' => 2],
+        ];
+        $position = 0;
+
+        $stub = $this->getMockBuilder('PDOStatement')->getMock();
+        assert($stub instanceof PDOStatement); // to suppress IDE type warnings
+        $stub->expects($this->any())
+            ->method('fetch')
+            ->will($this->returnCallback(function () use ($data, &$position) {
+                return $data[$position++];
+            }));
+        $result = new Result();
+        $result->initialize($stub, null);
+
+        $result->rewind();
+        $result->rewind();
+
+        $this->assertEquals(0, $result->key());
+        $this->assertEquals(1, $position);
+        $this->assertEquals($data[0], $result->current());
+
+        $result->next();
+        $this->assertEquals(1, $result->key());
+        $this->assertEquals(2, $position);
+        $this->assertEquals($data[1], $result->current());
     }
 }


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | maybe?
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes #196.

BC break can occur if one deliberately used this bug as a feature. But that should not be the case in sane projects.

