### PR TITLE
Fix integration test database cleanup issue 

### DIFF
--- a/test/integration/IntegrationTestListener.php
+++ b/test/integration/IntegrationTestListener.php
@@ -54,7 +54,7 @@ class IntegrationTestListener implements TestHook, TestListener
     {
         if (
             $suite->getName() !== 'integration test'
-            || empty($this->fixtureLoader)
+            || empty($this->fixtureLoaders)
         ) {
             return;
         }


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes


### Description
This is a bug fix to integration testing code.
This patch fixes the test databases not being dropped after integration tests have run.
This patch corrects a misnamed property, allowing the dropDatabase method to be called for each adapter under test, and the test databases to be cleaned up as intended.
Prior to the patch the test database would not be dropped, causing an issue when the integration test was re-run.
After the patch the text "Integration test ended." is visible in the phpunit output and the databases are dropped.
 