### PR TITLE
Fix issue with connection not released in specific scenario

### DIFF
--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -177,18 +177,17 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
         }
 
         if ($mode === self::QUERY_MODE_PREPARE) {
-            $this->lastPreparedStatement = null;
-            $this->lastPreparedStatement = $this->driver->createStatement($sql);
-            $this->lastPreparedStatement->prepare();
+            $lastPreparedStatement = $this->driver->createStatement($sql);
+            $lastPreparedStatement->prepare();
             if (is_array($parameters) || $parameters instanceof ParameterContainer) {
                 if (is_array($parameters)) {
-                    $this->lastPreparedStatement->setParameterContainer(new ParameterContainer($parameters));
+                    $lastPreparedStatement->setParameterContainer(new ParameterContainer($parameters));
                 } else {
-                    $this->lastPreparedStatement->setParameterContainer($parameters);
+                    $lastPreparedStatement->setParameterContainer($parameters);
                 }
-                $result = $this->lastPreparedStatement->execute();
+                $result = $lastPreparedStatement->execute();
             } else {
-                return $this->lastPreparedStatement;
+                return $lastPreparedStatement;
             }
         } else {
             $result = $this->driver->getConnection()->execute($sql);

--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -49,8 +49,6 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
     /** @var ResultSet\ResultSetInterface */
     protected $queryResultSetPrototype;
 
-    /** @var Driver\StatementInterface */
-    protected $lastPreparedStatement;
 
     /**
      * @param Driver\DriverInterface|array $driver

--- a/src/Adapter/Adapter.php
+++ b/src/Adapter/Adapter.php
@@ -49,7 +49,12 @@ class Adapter implements AdapterInterface, Profiler\ProfilerAwareInterface
     /** @var ResultSet\ResultSetInterface */
     protected $queryResultSetPrototype;
 
-
+    /**
+     * @deprecated
+     *
+     * @var Driver\StatementInterface
+     */
+    protected $lastPreparedStatement;
     /**
      * @param Driver\DriverInterface|array $driver
      * @throws Exception\InvalidArgumentException

--- a/test/integration/Adapter/Driver/Pdo/Mysql/TableGatewayAndAdapterTest.php
+++ b/test/integration/Adapter/Driver/Pdo/Mysql/TableGatewayAndAdapterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace LaminasIntegrationTest\Db\Adapter\Driver\Pdo\Mysql;
+
+use Laminas\Db\TableGateway\TableGateway;
+use PHPUnit\Framework\TestCase;
+
+use function array_fill;
+
+/**
+ * Usually mysql has 151 max connections by default.
+ * Set up a test where executed Laminas\Db\Adapter\Adapter::query and then using table gateway to fetch a row
+ * On tear down disconnected from the database and set the driver adapter on null
+ * Running many tests ended up in consuming all mysql connections and not releasing them
+ */
+class TableGatewayAndAdapterTest extends TestCase
+{
+    use AdapterTrait;
+
+    /**
+     * @dataProvider connections
+     */
+    public function testGetOutOfConnections(): void
+    {
+        $this->adapter->query('SELECT VERSION();');
+        $table  = new TableGateway(
+            'test',
+            $this->adapter
+        );
+        $select = $table->getSql()->select()->where(['name' => 'foo']);
+        $result = $table->selectWith($select);
+        self::assertCount(3, $result->current());
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->adapter->getDriver()->getConnection()->isConnected()) {
+            $this->adapter->getDriver()->getConnection()->disconnect();
+        }
+        $this->adapter = null;
+    }
+
+    public function connections(): array
+    {
+        return array_fill(0, 200, []);
+    }
+}


### PR DESCRIPTION
Use local variable instead of instance variable for storing select statement when in prepare mode


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Found the issue while running integration tests using the database adapter. If in the same  method you fetch something from database using `\Laminas\Db\Adapter\Adapter::query` in prepare mode and after use the table gateway to fetch something from the database, a reference to the PDO connection remains and is not released when trying to disconnect from the database.

Added a test case with the scenario with many tests in the data provider. On the tearDown I have disconnected from the database.
