### PR TITLE
Update docblock of having()

### DIFF
--- a/src/Sql/Select.php
+++ b/src/Sql/Select.php
@@ -302,7 +302,7 @@ class Select extends AbstractPreparableSql
     /**
      * Create having clause
      *
-     * @param Where|Closure|string|array $predicate
+     * @param Where|Having|Closure|string|array $predicate
      * @param  string $combination One of the OP_* constants from Predicate\PredicateSet
      * @return $this Provides a fluent interface
      */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
Update docblock of having() function. The code makes it clear that a Having object is a valid value for the $predicate argument. Update the docblock to make that explicit.