### PR TITLE
Feature/246 "and" and "or" methods

### DIFF
--- a/src/Sql/Predicate/Predicate.php
+++ b/src/Sql/Predicate/Predicate.php
@@ -436,6 +436,13 @@ class Predicate extends PredicateSet
         return $this;
     }
 
+    public function or(): Predicate
+    {
+        $this->nextPredicateCombineOperator = self::OP_OR;
+
+        return $this;
+    }
+
     /**
      * Overloading
      *
@@ -448,8 +455,7 @@ class Predicate extends PredicateSet
     {
         switch (strtolower($name)) {
             case 'or':
-                $this->nextPredicateCombineOperator = self::OP_OR;
-                break;
+                return $this->or();
             case 'and':
                 return $this->and();
             case 'nest':

--- a/src/Sql/Predicate/Predicate.php
+++ b/src/Sql/Predicate/Predicate.php
@@ -429,6 +429,13 @@ class Predicate extends PredicateSet
         return $this;
     }
 
+    public function and(): Predicate
+    {
+        $this->nextPredicateCombineOperator = self::OP_AND;
+
+        return $this;
+    }
+
     /**
      * Overloading
      *
@@ -444,8 +451,7 @@ class Predicate extends PredicateSet
                 $this->nextPredicateCombineOperator = self::OP_OR;
                 break;
             case 'and':
-                $this->nextPredicateCombineOperator = self::OP_AND;
-                break;
+                return $this->and();
             case 'nest':
                 return $this->nest();
             case 'unnest':

--- a/src/Sql/Predicate/Predicate.php
+++ b/src/Sql/Predicate/Predicate.php
@@ -453,16 +453,12 @@ class Predicate extends PredicateSet
      */
     public function __get($name)
     {
-        switch (strtolower($name)) {
-            case 'or':
-                return $this->or();
-            case 'and':
-                return $this->and();
-            case 'nest':
-                return $this->nest();
-            case 'unnest':
-                return $this->unnest();
-        }
-        return $this;
+        return match (strtolower($name)) {
+            'or' => $this->or(),
+            'and' => $this->and(),
+            'nest' => $this->nest(),
+            'unnest' => $this->unnest(),
+            default => $this,
+        };
     }
 }

--- a/src/Sql/Predicate/Predicate.php
+++ b/src/Sql/Predicate/Predicate.php
@@ -447,11 +447,8 @@ class Predicate extends PredicateSet
      * Overloading
      *
      * Overloads "or", "and", "nest", and "unnest"
-     *
-     * @param  string $name
-     * @return $this Provides a fluent interface
      */
-    public function __get($name)
+    public function __get(string $name): Predicate
     {
         return match (strtolower($name)) {
             'or' => $this->or(),


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes?

### Description

I'm simply adding methods for "and" and "or" to the Predicate class as proposed in #246.  

Since the library is targeting PHP 8.1 onwards I've made some version specific type annotations as well as converting a switch to a match expression.
