### PR TITLE
Correctly types $event property as ?EventFeature\TableGatewayEvent instead of null

### DIFF
--- a/src/TableGateway/Feature/EventFeature.php
+++ b/src/TableGateway/Feature/EventFeature.php
@@ -9,7 +9,6 @@ use Laminas\Db\Sql\Delete;
 use Laminas\Db\Sql\Insert;
 use Laminas\Db\Sql\Select;
 use Laminas\Db\Sql\Update;
-use Laminas\Db\TableGateway\Feature\EventFeature\TableGatewayEvent;
 use Laminas\Db\TableGateway\TableGateway;
 use Laminas\EventManager\EventManager;
 use Laminas\EventManager\EventManagerInterface;
@@ -24,7 +23,7 @@ class EventFeature extends AbstractFeature implements
     /** @var EventManagerInterface */
     protected $eventManager;
 
-    /** @var ?TableGatewayEvent */
+    /** @var ?EventFeature\TableGatewayEvent */
     protected $event;
 
     public function __construct(

--- a/src/TableGateway/Feature/EventFeature.php
+++ b/src/TableGateway/Feature/EventFeature.php
@@ -9,8 +9,8 @@ use Laminas\Db\Sql\Delete;
 use Laminas\Db\Sql\Insert;
 use Laminas\Db\Sql\Select;
 use Laminas\Db\Sql\Update;
+use Laminas\Db\TableGateway\Feature\EventFeature\TableGatewayEvent;
 use Laminas\Db\TableGateway\TableGateway;
-use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\EventManager;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\EventsCapableInterface;
@@ -24,7 +24,7 @@ class EventFeature extends AbstractFeature implements
     /** @var EventManagerInterface */
     protected $eventManager;
 
-    /** @var ?EventInterface */
+    /** @var ?TableGatewayEvent */
     protected $event;
 
     public function __construct(

--- a/src/TableGateway/Feature/EventFeature.php
+++ b/src/TableGateway/Feature/EventFeature.php
@@ -10,6 +10,7 @@ use Laminas\Db\Sql\Insert;
 use Laminas\Db\Sql\Select;
 use Laminas\Db\Sql\Update;
 use Laminas\Db\TableGateway\TableGateway;
+use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\EventManager;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\EventManager\EventsCapableInterface;
@@ -23,7 +24,7 @@ class EventFeature extends AbstractFeature implements
     /** @var EventManagerInterface */
     protected $eventManager;
 
-    /** @var null */
+    /** @var ?EventInterface */
     protected $event;
 
     public function __construct(


### PR DESCRIPTION
Correctly types $event property to EventInterface instead of just null

<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

<!--

Tell us about why this change is necessary:
The EventFeature class property $event was typed to just null. This improves typing to ?EventInterface.

Please see:
https://github.com/laminas/laminas-db/blob/a03d8df79c36c07b9031d05bfd605dfed3ddf9a3/src/TableGateway/Feature/EventFeature.php#L27
