### PR TITLE
Adds correct typing for EventFeature $event property

### DIFF
--- a/src/TableGateway/Feature/EventFeature.php
+++ b/src/TableGateway/Feature/EventFeature.php
@@ -23,7 +23,7 @@ class EventFeature extends AbstractFeature implements
     /** @var EventManagerInterface */
     protected $eventManager;
 
-    /** @var null */
+    /** @var ?EventFeature\TableGatewayEvent */
     protected $event;
 
     public function __construct(


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Sorry, I had to ditch my old fork. For some reason I could not pull in the 2.20.x branch.... I might be to used to using vscode :(

Tell us about why this change is necessary:
Improves typing for the $event property docblock to match the constructor typing

- Are you adding documentation?
 No

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
Updating typing for a class property

- Are you fixing a BC Break?
No

- Are you adding something the library currently does not support?
No

- Are you refactoring code?
No
