### PR TITLE
Add maintenance status notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@
 >
 > You trust us enough to use our software. We ask that you trust us to say the truth on this. We need your help. Go out and protest this unnecessary war. Stop the bloodshed. Say "stop the war!"
 
+> [!CAUTION]
+> This package is considered feature-complete, and is now in **security-only** maintenance mode, following a [decision by the Technical Steering Committee](https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2022-02-07-TSC-Minutes.md#is-laminas-db-abandoned).
+> If you have a security issue, please [follow our security reporting guidelines](https://getlaminas.org/security/).
+> If you wish to take on the role of maintainer, please [nominate yourself](https://github.com/laminas/technical-steering-committee/issues/new?assignees=&labels=Nomination&template=Maintainer_Nomination.md&title=%5BNOMINATION%5D%5BMAINTAINER%5D%3A+%7Bname+of+person+being+nominated%7D)
+
 `Laminas\Db` is a component that abstract the access to a Database using an object
 oriented API to build the queries. `Laminas\Db` consumes different storage adapters
 to access different database vendors such as MySQL, PostgreSQL, Oracle, IBM DB2,


### PR DESCRIPTION
The README now includes a cautionary note indicating that the package is in security-only maintenance mode. It advises users on how to report security issues and offers guidance for those interested in taking on the role of maintainer. This update reflects the decisions made by the Technical Steering Committee.
